### PR TITLE
Generate about page from markdown file using pulldown-cmark

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y imagemagick webp libavif-bin
-          magick -version
+          convert -version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,15 @@
-name: Build and Deploy
+name: Test
 
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
-  # Run tests first - must pass before build/deploy
   test:
     runs-on: ubuntu-latest
     steps:
@@ -36,11 +30,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y imagemagick webp libavif-bin
+          # Verify ImageMagick is working
           magick -version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Cache Cargo dependencies
       - name: Cache Cargo
         uses: actions/cache@v4
         with:
@@ -66,58 +62,37 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lighttable-binary
+          name: lighttable-linux
           path: target/release/lighttable
-          retention-days: 1
+          retention-days: 7
 
-  build:
+  # Lint job runs in parallel with tests
+  lint:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Cache apt packages for image processing
-      - name: Cache apt packages
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Cargo
         uses: actions/cache@v4
-        id: apt-cache
         with:
           path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-imagemagick-v1
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y imagemagick webp libavif-bin
+      - name: Check formatting
+        run: cargo fmt --check
 
-      - name: Download binary artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: lighttable-binary
-          path: ./bin
-
-      - name: Make binary executable
-        run: chmod +x ./bin/lighttable
-
-      - name: Build site
-        run: |
-          ./bin/lighttable build images dist
-          cp CNAME dist/
-
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Run clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,22 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Cache apt packages
-      - name: Cache apt packages
-        uses: actions/cache@v4
-        id: apt-cache
-        with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-imagemagick-v1
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y imagemagick webp libavif-bin
-          # Verify ImageMagick is working
-          magick -version
+          # Verify ImageMagick is working (Ubuntu uses 'convert' not 'magick')
+          convert -version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,7 @@ name = "lighttable"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "pulldown-cmark",
  "rayon",
  "serde",
  "serde_json",
@@ -238,6 +248,25 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -390,10 +419,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,10 +185,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -213,6 +235,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "walkdir",
 ]
 
@@ -369,6 +392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +449,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicase"
@@ -483,6 +556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ name = "lighttable"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "maud",
  "pulldown-cmark",
  "rayon",
  "serde",
@@ -244,6 +245,28 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "maud"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
@@ -262,6 +285,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -514,6 +560,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+pulldown-cmark = "0.13"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+toml = "0.8"
 walkdir = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+maud = "0.26"
 pulldown-cmark = "0.13"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4,11 +4,11 @@ LightTable requires these system-level tools for image processing.
 
 ## Required
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| ImageMagick | 7.x | Resizing, format conversion, EXIF handling |
-| libavif | 1.x | AVIF encoding (via ImageMagick) |
-| libwebp | 1.x | WebP encoding (via ImageMagick) |
+| Tool | Commands Used | Purpose |
+|------|---------------|---------|
+| ImageMagick | `convert`, `identify` | Resizing, format conversion, dimension detection |
+| libavif | - | AVIF encoding (via ImageMagick) |
+| libwebp | - | WebP encoding (via ImageMagick) |
 
 ## Installation
 
@@ -34,12 +34,24 @@ sudo pacman -S imagemagick libwebp libavif
 ### Verify Installation
 
 ```bash
-# Check ImageMagick with AVIF/WebP support
-magick -list format | grep -E 'AVIF|WEBP'
+# Check required commands exist
+convert -version
+identify -version
+
+# Check AVIF/WebP support
+convert -list format | grep -E 'AVIF|WEBP'
 ```
 
 Expected output should show both AVIF and WEBP formats.
 
+## Automated Installation
+
+Use the provided script which handles detection and verification:
+
+```bash
+./scripts/install-deps.sh
+```
+
 ## GitHub Actions
 
-The workflow uses `scripts/install-deps.sh` which handles Ubuntu installation.
+The CI workflow installs dependencies via apt and verifies the `convert` command.

--- a/fixtures/images/about.md
+++ b/fixtures/images/about.md
@@ -1,4 +1,4 @@
-About This Gallery
+# About This Gallery
 
 This is a sample photography portfolio built with LightTable.
 

--- a/fixtures/images/config.toml
+++ b/fixtures/images/config.toml
@@ -1,0 +1,8 @@
+# Test fixture config
+[colors.light]
+background = "#fafafa"
+text = "#222222"
+
+[colors.dark]
+background = "#1a1a1a"
+text = "#dddddd"

--- a/images/about.md
+++ b/images/about.md
@@ -1,4 +1,4 @@
-About
+# About
 
 This is a photography portfolio showcasing work from various locations and projects.
 

--- a/images/config.toml
+++ b/images/config.toml
@@ -1,0 +1,23 @@
+# LightTable Configuration
+# Place this file in your content root directory (same as your images)
+
+# Color scheme configuration
+# All colors are optional - defaults will be used for any missing values
+
+[colors.light]
+# Light mode colors (when prefers-color-scheme: light or no preference)
+background = "#ffffff"
+text = "#111111"
+text_muted = "#666666"    # Used for nav menu, breadcrumbs, captions
+border = "#e0e0e0"
+link = "#333333"
+link_hover = "#000000"
+
+[colors.dark]
+# Dark mode colors (when prefers-color-scheme: dark)
+background = "#0a0a0a"
+text = "#eeeeee"
+text_muted = "#999999"    # Used for nav menu, breadcrumbs, captions
+border = "#333333"
+link = "#cccccc"
+link_hover = "#ffffff"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # Install system dependencies for LightTable
 # Detects OS and installs appropriately
+#
+# Required commands after install:
+# - convert (ImageMagick)
+# - identify (ImageMagick)
 
 install_macos() {
     echo "==> Installing dependencies via Homebrew"
@@ -27,27 +31,35 @@ install_arch() {
 verify_install() {
     echo "==> Verifying installation"
 
-    # Check for ImageMagick (either magick or convert)
-    if command -v magick &> /dev/null; then
-        IM_CMD="magick"
-    elif command -v convert &> /dev/null; then
-        IM_CMD="convert"
-    else
-        echo "Error: ImageMagick not found"
+    # Check for convert command
+    if ! command -v convert &> /dev/null; then
+        echo "Error: 'convert' command not found"
+        echo "ImageMagick must be installed with the 'convert' and 'identify' commands"
         exit 1
     fi
-    echo "Found ImageMagick: $IM_CMD"
+    echo "Found: convert"
+
+    # Check for identify command
+    if ! command -v identify &> /dev/null; then
+        echo "Error: 'identify' command not found"
+        echo "ImageMagick must be installed with the 'convert' and 'identify' commands"
+        exit 1
+    fi
+    echo "Found: identify"
 
     # Check for AVIF support
-    if ! $IM_CMD -list format | grep -q AVIF; then
-        echo "Warning: ImageMagick lacks AVIF support, will use WebP only"
+    if ! convert -list format | grep -q AVIF; then
+        echo "Warning: ImageMagick lacks AVIF support"
+        exit 1
     fi
+    echo "Found: AVIF support"
 
     # Check for WebP support
-    if ! $IM_CMD -list format | grep -q WEBP; then
+    if ! convert -list format | grep -q WEBP; then
         echo "Error: ImageMagick lacks WebP support"
         exit 1
     fi
+    echo "Found: WebP support"
 
     echo "==> All dependencies installed and verified"
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,178 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+}
+
+/// Site configuration loaded from config.toml
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SiteConfig {
+    pub colors: ColorConfig,
+}
+
+impl Default for SiteConfig {
+    fn default() -> Self {
+        Self {
+            colors: ColorConfig::default(),
+        }
+    }
+}
+
+/// Color configuration for light and dark modes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ColorConfig {
+    pub light: ColorScheme,
+    pub dark: ColorScheme,
+}
+
+impl Default for ColorConfig {
+    fn default() -> Self {
+        Self {
+            light: ColorScheme::default_light(),
+            dark: ColorScheme::default_dark(),
+        }
+    }
+}
+
+/// Individual color scheme
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ColorScheme {
+    /// Background color
+    pub background: String,
+    /// Primary text color
+    pub text: String,
+    /// Muted/secondary text color (used for nav menu, breadcrumbs)
+    pub text_muted: String,
+    /// Border color
+    pub border: String,
+    /// Link color
+    pub link: String,
+    /// Link hover color
+    pub link_hover: String,
+}
+
+impl ColorScheme {
+    pub fn default_light() -> Self {
+        Self {
+            background: "#ffffff".to_string(),
+            text: "#111111".to_string(),
+            text_muted: "#666666".to_string(),
+            border: "#e0e0e0".to_string(),
+            link: "#333333".to_string(),
+            link_hover: "#000000".to_string(),
+        }
+    }
+
+    pub fn default_dark() -> Self {
+        Self {
+            background: "#0a0a0a".to_string(),
+            text: "#eeeeee".to_string(),
+            text_muted: "#999999".to_string(),
+            border: "#333333".to_string(),
+            link: "#cccccc".to_string(),
+            link_hover: "#ffffff".to_string(),
+        }
+    }
+}
+
+impl Default for ColorScheme {
+    fn default() -> Self {
+        Self::default_light()
+    }
+}
+
+/// Load config from config.toml in the given directory
+pub fn load_config(root: &Path) -> Result<SiteConfig, ConfigError> {
+    let config_path = root.join("config.toml");
+    if !config_path.exists() {
+        return Ok(SiteConfig::default());
+    }
+
+    let content = fs::read_to_string(&config_path)?;
+    let config: SiteConfig = toml::from_str(&content)?;
+    Ok(config)
+}
+
+/// Generate CSS custom properties from color config
+pub fn generate_color_css(colors: &ColorConfig) -> String {
+    format!(
+        r#":root {{
+    --color-bg: {light_bg};
+    --color-text: {light_text};
+    --color-text-muted: {light_text_muted};
+    --color-border: {light_border};
+    --color-link: {light_link};
+    --color-link-hover: {light_link_hover};
+}}
+
+@media (prefers-color-scheme: dark) {{
+    :root {{
+        --color-bg: {dark_bg};
+        --color-text: {dark_text};
+        --color-text-muted: {dark_text_muted};
+        --color-border: {dark_border};
+        --color-link: {dark_link};
+        --color-link-hover: {dark_link_hover};
+    }}
+}}"#,
+        light_bg = colors.light.background,
+        light_text = colors.light.text,
+        light_text_muted = colors.light.text_muted,
+        light_border = colors.light.border,
+        light_link = colors.light.link,
+        light_link_hover = colors.light.link_hover,
+        dark_bg = colors.dark.background,
+        dark_text = colors.dark.text,
+        dark_text_muted = colors.dark.text_muted,
+        dark_border = colors.dark.border,
+        dark_link = colors.dark.link,
+        dark_link_hover = colors.dark.link_hover,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_colors() {
+        let config = SiteConfig::default();
+        assert_eq!(config.colors.light.background, "#ffffff");
+        assert_eq!(config.colors.dark.background, "#0a0a0a");
+    }
+
+    #[test]
+    fn parse_partial_config() {
+        let toml = r##"
+[colors.light]
+background = "#fafafa"
+"##;
+        let config: SiteConfig = toml::from_str(toml).unwrap();
+        // Overridden value
+        assert_eq!(config.colors.light.background, "#fafafa");
+        // Default values preserved
+        assert_eq!(config.colors.light.text, "#111111");
+        assert_eq!(config.colors.dark.background, "#0a0a0a");
+    }
+
+    #[test]
+    fn generate_css_uses_config_colors() {
+        let mut colors = ColorConfig::default();
+        colors.light.background = "#f0f0f0".to_string();
+        colors.dark.background = "#1a1a1a".to_string();
+
+        let css = generate_color_css(&colors);
+        assert!(css.contains("--color-bg: #f0f0f0"));
+        assert!(css.contains("--color-bg: #1a1a1a"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,54 @@
+//! Site configuration module.
+//!
+//! Handles loading and parsing the `config.toml` file from the content root directory.
+//! Configuration is optional - sensible defaults are used when no config file exists.
+//!
+//! ## Config File Location
+//!
+//! Place `config.toml` in the same directory as your images (the content root):
+//!
+//! ```text
+//! images/
+//! ├── config.toml          # Site configuration
+//! ├── about.md             # Optional about page
+//! ├── 010-Landscapes/
+//! │   └── ...
+//! └── 020-Portraits/
+//!     └── ...
+//! ```
+//!
+//! ## Configuration Options
+//!
+//! ```toml
+//! # All options are optional - defaults shown below
+//!
+//! [colors.light]
+//! background = "#ffffff"
+//! text = "#111111"
+//! text_muted = "#666666"    # Nav menu, breadcrumbs, captions
+//! border = "#e0e0e0"
+//! link = "#333333"
+//! link_hover = "#000000"
+//!
+//! [colors.dark]
+//! background = "#0a0a0a"
+//! text = "#eeeeee"
+//! text_muted = "#999999"
+//! border = "#333333"
+//! link = "#cccccc"
+//! link_hover = "#ffffff"
+//! ```
+//!
+//! ## Partial Configuration
+//!
+//! You can override just the values you want to change:
+//!
+//! ```toml
+//! # Only override the light mode background
+//! [colors.light]
+//! background = "#fafafa"
+//! ```
+
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;

--- a/src/imaging/backend.rs
+++ b/src/imaging/backend.rs
@@ -94,12 +94,12 @@ impl ImageBackend for ImageMagickBackend {
             )));
         }
 
-        let width: u32 = parts[0].parse().map_err(|_| {
-            BackendError::InvalidOutput(format!("Invalid width: {}", parts[0]))
-        })?;
-        let height: u32 = parts[1].parse().map_err(|_| {
-            BackendError::InvalidOutput(format!("Invalid height: {}", parts[1]))
-        })?;
+        let width: u32 = parts[0]
+            .parse()
+            .map_err(|_| BackendError::InvalidOutput(format!("Invalid width: {}", parts[0])))?;
+        let height: u32 = parts[1]
+            .parse()
+            .map_err(|_| BackendError::InvalidOutput(format!("Invalid height: {}", parts[1])))?;
 
         Ok(Dimensions { width, height })
     }

--- a/src/imaging/backend.rs
+++ b/src/imaging/backend.rs
@@ -1,0 +1,329 @@
+//! Image processing backend trait and implementations.
+//!
+//! The `ImageBackend` trait abstracts the actual image processing,
+//! allowing for different implementations (ImageMagick, pure Rust, mock).
+
+use super::params::{ResizeParams, ThumbnailParams};
+use std::path::Path;
+use std::process::Command;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BackendError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Command failed: {0}")]
+    CommandFailed(String),
+    #[error("Invalid output: {0}")]
+    InvalidOutput(String),
+}
+
+/// Result of an identify operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Trait for image processing backends.
+///
+/// Implementations execute the actual image operations.
+/// This allows for:
+/// - Different backends (ImageMagick, pure Rust)
+/// - Mock backends for testing
+pub trait ImageBackend {
+    /// Get image dimensions.
+    fn identify(&self, path: &Path) -> Result<Dimensions, BackendError>;
+
+    /// Execute a resize operation.
+    fn resize(&self, params: &ResizeParams) -> Result<(), BackendError>;
+
+    /// Execute a thumbnail operation (resize + center crop).
+    fn thumbnail(&self, params: &ThumbnailParams) -> Result<(), BackendError>;
+}
+
+/// ImageMagick backend using the `convert` command.
+///
+/// Uses ImageMagick 6's `convert` and `identify` commands.
+/// This is the standard on Ubuntu/Debian and CI environments.
+pub struct ImageMagickBackend;
+
+impl ImageMagickBackend {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn run_convert(&self, args: &[&str]) -> Result<(), BackendError> {
+        let output = Command::new("convert").args(args).output()?;
+
+        if !output.status.success() {
+            return Err(BackendError::CommandFailed(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ImageMagickBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageBackend for ImageMagickBackend {
+    fn identify(&self, path: &Path) -> Result<Dimensions, BackendError> {
+        let output = Command::new("identify")
+            .args(["-format", "%w %h", path.to_str().unwrap()])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(BackendError::CommandFailed(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+            ));
+        }
+
+        let dims = String::from_utf8_lossy(&output.stdout);
+        let parts: Vec<&str> = dims.split_whitespace().collect();
+
+        if parts.len() != 2 {
+            return Err(BackendError::InvalidOutput(format!(
+                "Expected 'width height', got: {}",
+                dims
+            )));
+        }
+
+        let width: u32 = parts[0].parse().map_err(|_| {
+            BackendError::InvalidOutput(format!("Invalid width: {}", parts[0]))
+        })?;
+        let height: u32 = parts[1].parse().map_err(|_| {
+            BackendError::InvalidOutput(format!("Invalid height: {}", parts[1]))
+        })?;
+
+        Ok(Dimensions { width, height })
+    }
+
+    fn resize(&self, params: &ResizeParams) -> Result<(), BackendError> {
+        let size = format!("{}x{}", params.width, params.height);
+        let quality = params.quality.value().to_string();
+
+        // Determine output format and add format-specific options
+        let output_path = params.output.to_str().unwrap();
+        let is_avif = output_path.ends_with(".avif");
+
+        let mut args = vec![
+            params.source.to_str().unwrap(),
+            "-resize",
+            &size,
+            "-quality",
+            &quality,
+        ];
+
+        // AVIF-specific: speed setting for faster encoding
+        let heic_speed;
+        if is_avif {
+            heic_speed = "heic:speed=6".to_string();
+            args.push("-define");
+            args.push(&heic_speed);
+        }
+
+        args.push(output_path);
+
+        self.run_convert(&args)
+    }
+
+    fn thumbnail(&self, params: &ThumbnailParams) -> Result<(), BackendError> {
+        let fill_size = format!("{}x{}^", params.fill_width, params.fill_height);
+        let crop_size = format!("{}x{}", params.crop_width, params.crop_height);
+        let quality = params.quality.value().to_string();
+
+        let mut args = vec![
+            params.source.to_str().unwrap(),
+            "-resize",
+            &fill_size,
+            "-gravity",
+            "center",
+            "-extent",
+            &crop_size,
+            "-quality",
+            &quality,
+        ];
+
+        // Optional sharpening
+        let sharpen_str;
+        if let Some(sharpening) = params.sharpening {
+            sharpen_str = format!("{}x{}", sharpening.radius, sharpening.sigma);
+            args.push("-sharpen");
+            args.push(&sharpen_str);
+        }
+
+        args.push(params.output.to_str().unwrap());
+
+        self.run_convert(&args)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::imaging::Sharpening;
+    use std::cell::RefCell;
+
+    /// Mock backend that records operations without executing them.
+    #[derive(Default)]
+    pub struct MockBackend {
+        pub identify_results: RefCell<Vec<Dimensions>>,
+        pub operations: RefCell<Vec<RecordedOp>>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RecordedOp {
+        Identify(String),
+        Resize {
+            source: String,
+            output: String,
+            width: u32,
+            height: u32,
+            quality: u32,
+        },
+        Thumbnail {
+            source: String,
+            output: String,
+            fill_width: u32,
+            fill_height: u32,
+            crop_width: u32,
+            crop_height: u32,
+            quality: u32,
+            sharpening: Option<(f32, f32)>,
+        },
+    }
+
+    impl MockBackend {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn with_dimensions(dims: Vec<Dimensions>) -> Self {
+            Self {
+                identify_results: RefCell::new(dims),
+                operations: RefCell::new(Vec::new()),
+            }
+        }
+
+        pub fn get_operations(&self) -> Vec<RecordedOp> {
+            self.operations.borrow().clone()
+        }
+    }
+
+    impl ImageBackend for MockBackend {
+        fn identify(&self, path: &Path) -> Result<Dimensions, BackendError> {
+            self.operations
+                .borrow_mut()
+                .push(RecordedOp::Identify(path.to_string_lossy().to_string()));
+
+            self.identify_results
+                .borrow_mut()
+                .pop()
+                .ok_or_else(|| BackendError::InvalidOutput("No mock dimensions".to_string()))
+        }
+
+        fn resize(&self, params: &ResizeParams) -> Result<(), BackendError> {
+            self.operations.borrow_mut().push(RecordedOp::Resize {
+                source: params.source.to_string_lossy().to_string(),
+                output: params.output.to_string_lossy().to_string(),
+                width: params.width,
+                height: params.height,
+                quality: params.quality.value(),
+            });
+            Ok(())
+        }
+
+        fn thumbnail(&self, params: &ThumbnailParams) -> Result<(), BackendError> {
+            self.operations.borrow_mut().push(RecordedOp::Thumbnail {
+                source: params.source.to_string_lossy().to_string(),
+                output: params.output.to_string_lossy().to_string(),
+                fill_width: params.fill_width,
+                fill_height: params.fill_height,
+                crop_width: params.crop_width,
+                crop_height: params.crop_height,
+                quality: params.quality.value(),
+                sharpening: params.sharpening.map(|s| (s.radius, s.sigma)),
+            });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn mock_records_identify() {
+        let backend = MockBackend::with_dimensions(vec![Dimensions {
+            width: 800,
+            height: 600,
+        }]);
+
+        let result = backend.identify(Path::new("/test/image.jpg")).unwrap();
+        assert_eq!(result.width, 800);
+        assert_eq!(result.height, 600);
+
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(&ops[0], RecordedOp::Identify(p) if p == "/test/image.jpg"));
+    }
+
+    #[test]
+    fn mock_records_resize() {
+        let backend = MockBackend::new();
+
+        backend
+            .resize(&ResizeParams {
+                source: "/source.jpg".into(),
+                output: "/output.avif".into(),
+                width: 800,
+                height: 600,
+                quality: super::super::params::Quality::new(90),
+            })
+            .unwrap();
+
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(
+            &ops[0],
+            RecordedOp::Resize {
+                width: 800,
+                height: 600,
+                quality: 90,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn mock_records_thumbnail_with_sharpening() {
+        let backend = MockBackend::new();
+
+        backend
+            .thumbnail(&ThumbnailParams {
+                source: "/source.jpg".into(),
+                output: "/thumb.webp".into(),
+                fill_width: 500,
+                fill_height: 625,
+                crop_width: 400,
+                crop_height: 500,
+                quality: super::super::params::Quality::new(85),
+                sharpening: Some(Sharpening::light()),
+            })
+            .unwrap();
+
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(
+            &ops[0],
+            RecordedOp::Thumbnail {
+                crop_width: 400,
+                crop_height: 500,
+                sharpening: Some((0.0, 0.5)),
+                ..
+            }
+        ));
+    }
+}

--- a/src/imaging/calculations.rs
+++ b/src/imaging/calculations.rs
@@ -1,0 +1,255 @@
+//! Pure calculation functions for image dimensions.
+//!
+//! All functions here are pure and testable without any I/O or images.
+
+/// Calculate thumbnail dimensions from aspect ratio and short edge size.
+///
+/// # Arguments
+/// * `aspect` - Target aspect ratio as (width, height)
+/// * `short_edge` - Size of the shorter edge in pixels
+///
+/// # Returns
+/// * `(width, height)` - Final thumbnail dimensions
+///
+/// # Examples
+/// ```
+/// # use lighttable::imaging::calculate_thumbnail_dimensions;
+/// // 4:5 portrait with short edge 400px → 400x500
+/// assert_eq!(calculate_thumbnail_dimensions((4, 5), 400), (400, 500));
+///
+/// // 16:9 landscape with short edge 180px → 320x180
+/// assert_eq!(calculate_thumbnail_dimensions((16, 9), 180), (320, 180));
+/// ```
+pub fn calculate_thumbnail_dimensions(aspect: (u32, u32), short_edge: u32) -> (u32, u32) {
+    let (aspect_w, aspect_h) = aspect;
+
+    if aspect_w <= aspect_h {
+        // Portrait or square: width is the short edge
+        let w = short_edge;
+        let h = (w as f64 * aspect_h as f64 / aspect_w as f64).round() as u32;
+        (w, h)
+    } else {
+        // Landscape: height is the short edge
+        let h = short_edge;
+        let w = (h as f64 * aspect_w as f64 / aspect_h as f64).round() as u32;
+        (w, h)
+    }
+}
+
+/// Calculate dimensions needed to fill a target area (resize before crop).
+///
+/// Returns dimensions that completely cover the target area while maintaining
+/// the source aspect ratio. One dimension will match exactly, the other may exceed.
+///
+/// # Arguments
+/// * `source` - Original image dimensions (width, height)
+/// * `target` - Target area dimensions (width, height)
+///
+/// # Returns
+/// * `(width, height)` - Fill dimensions (at least one matches target)
+pub fn calculate_fill_dimensions(source: (u32, u32), target: (u32, u32)) -> (u32, u32) {
+    let (src_w, src_h) = source;
+    let (tgt_w, tgt_h) = target;
+
+    let src_aspect = src_w as f64 / src_h as f64;
+    let tgt_aspect = tgt_w as f64 / tgt_h as f64;
+
+    if src_aspect > tgt_aspect {
+        // Source is wider: height will match, width will exceed
+        let h = tgt_h;
+        let w = (h as f64 * src_aspect).round() as u32;
+        (w, h)
+    } else {
+        // Source is taller: width will match, height will exceed
+        let w = tgt_w;
+        let h = (w as f64 / src_aspect).round() as u32;
+        (w, h)
+    }
+}
+
+/// Represents a single responsive size to generate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponsiveSize {
+    /// Target size (longer edge).
+    pub target: u32,
+    /// Calculated output width.
+    pub width: u32,
+    /// Calculated output height.
+    pub height: u32,
+}
+
+/// Calculate which responsive sizes to generate and their dimensions.
+///
+/// Filters out sizes larger than the original and calculates output dimensions
+/// preserving aspect ratio. If all requested sizes exceed the original,
+/// returns the original size as the only entry.
+///
+/// # Arguments
+/// * `original` - Original image dimensions (width, height)
+/// * `sizes` - Requested breakpoint sizes (on the longer edge)
+///
+/// # Returns
+/// * Vector of sizes to generate with their dimensions
+pub fn calculate_responsive_sizes(original: (u32, u32), sizes: &[u32]) -> Vec<ResponsiveSize> {
+    let (orig_w, orig_h) = original;
+    let longer_edge = orig_w.max(orig_h);
+
+    let mut result: Vec<ResponsiveSize> = sizes
+        .iter()
+        .filter(|&&size| size <= longer_edge)
+        .map(|&target_size| {
+            let (out_w, out_h) = if orig_w >= orig_h {
+                // Landscape or square
+                let ratio = target_size as f64 / orig_w as f64;
+                (target_size, (orig_h as f64 * ratio).round() as u32)
+            } else {
+                // Portrait
+                let ratio = target_size as f64 / orig_h as f64;
+                ((orig_w as f64 * ratio).round() as u32, target_size)
+            };
+
+            ResponsiveSize {
+                target: target_size,
+                width: out_w,
+                height: out_h,
+            }
+        })
+        .collect();
+
+    // If original is smaller than all requested sizes, use original
+    if result.is_empty() {
+        result.push(ResponsiveSize {
+            target: longer_edge,
+            width: orig_w,
+            height: orig_h,
+        });
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // calculate_thumbnail_dimensions tests
+    // =========================================================================
+
+    #[test]
+    fn thumbnail_portrait_aspect() {
+        // 4:5 with short edge 400 → 400x500
+        assert_eq!(calculate_thumbnail_dimensions((4, 5), 400), (400, 500));
+    }
+
+    #[test]
+    fn thumbnail_landscape_aspect() {
+        // 16:9 with short edge 180 → 320x180
+        assert_eq!(calculate_thumbnail_dimensions((16, 9), 180), (320, 180));
+    }
+
+    #[test]
+    fn thumbnail_square_aspect() {
+        // 1:1 with short edge 200 → 200x200
+        assert_eq!(calculate_thumbnail_dimensions((1, 1), 200), (200, 200));
+    }
+
+    #[test]
+    fn thumbnail_extreme_portrait() {
+        // 1:3 with short edge 100 → 100x300
+        assert_eq!(calculate_thumbnail_dimensions((1, 3), 100), (100, 300));
+    }
+
+    #[test]
+    fn thumbnail_extreme_landscape() {
+        // 3:1 with short edge 100 → 300x100
+        assert_eq!(calculate_thumbnail_dimensions((3, 1), 100), (300, 100));
+    }
+
+    // =========================================================================
+    // calculate_fill_dimensions tests
+    // =========================================================================
+
+    #[test]
+    fn fill_wider_source_to_portrait_target() {
+        // 800x600 (4:3) → 400x500 target
+        // Source is wider, so height matches: 500, width = 500 * (4/3) = 667
+        assert_eq!(calculate_fill_dimensions((800, 600), (400, 500)), (667, 500));
+    }
+
+    #[test]
+    fn fill_taller_source_to_landscape_target() {
+        // 600x800 (3:4) → 500x400 target
+        // Source is taller, so width matches: 500, height = 500 * (4/3) = 667
+        assert_eq!(calculate_fill_dimensions((600, 800), (500, 400)), (500, 667));
+    }
+
+    #[test]
+    fn fill_same_aspect_ratio() {
+        // 800x600 (4:3) → 400x300 target (also 4:3)
+        // Perfect match
+        assert_eq!(calculate_fill_dimensions((800, 600), (400, 300)), (400, 300));
+    }
+
+    #[test]
+    fn fill_square_source_to_portrait() {
+        // 400x400 (1:1) → 200x300 target
+        // Source is wider (1:1 > 2:3), height matches: 300, width = 300
+        assert_eq!(calculate_fill_dimensions((400, 400), (200, 300)), (300, 300));
+    }
+
+    // =========================================================================
+    // calculate_responsive_sizes tests
+    // =========================================================================
+
+    #[test]
+    fn responsive_filters_larger_sizes() {
+        let sizes = calculate_responsive_sizes((1000, 800), &[800, 1400, 2080]);
+        assert_eq!(sizes.len(), 1);
+        assert_eq!(sizes[0].target, 800);
+    }
+
+    #[test]
+    fn responsive_calculates_dimensions_landscape() {
+        // 2000x1500 landscape, target 1000 on longer edge
+        let sizes = calculate_responsive_sizes((2000, 1500), &[1000]);
+        assert_eq!(sizes.len(), 1);
+        assert_eq!(sizes[0].width, 1000);
+        assert_eq!(sizes[0].height, 750); // 1500 * (1000/2000) = 750
+    }
+
+    #[test]
+    fn responsive_calculates_dimensions_portrait() {
+        // 1500x2000 portrait, target 1000 on longer edge
+        let sizes = calculate_responsive_sizes((1500, 2000), &[1000]);
+        assert_eq!(sizes.len(), 1);
+        assert_eq!(sizes[0].width, 750); // 1500 * (1000/2000) = 750
+        assert_eq!(sizes[0].height, 1000);
+    }
+
+    #[test]
+    fn responsive_falls_back_to_original_when_all_exceed() {
+        // 500x400, all sizes exceed
+        let sizes = calculate_responsive_sizes((500, 400), &[800, 1400, 2080]);
+        assert_eq!(sizes.len(), 1);
+        assert_eq!(sizes[0].target, 500); // Longer edge
+        assert_eq!(sizes[0].width, 500);
+        assert_eq!(sizes[0].height, 400);
+    }
+
+    #[test]
+    fn responsive_preserves_order() {
+        let sizes = calculate_responsive_sizes((3000, 2000), &[800, 1400, 2080]);
+        assert_eq!(sizes.len(), 3);
+        assert_eq!(sizes[0].target, 800);
+        assert_eq!(sizes[1].target, 1400);
+        assert_eq!(sizes[2].target, 2080);
+    }
+
+    #[test]
+    fn responsive_empty_sizes_returns_original() {
+        let sizes = calculate_responsive_sizes((1000, 800), &[]);
+        assert_eq!(sizes.len(), 1);
+        assert_eq!(sizes[0].target, 1000);
+    }
+}

--- a/src/imaging/calculations.rs
+++ b/src/imaging/calculations.rs
@@ -174,28 +174,40 @@ mod tests {
     fn fill_wider_source_to_portrait_target() {
         // 800x600 (4:3) → 400x500 target
         // Source is wider, so height matches: 500, width = 500 * (4/3) = 667
-        assert_eq!(calculate_fill_dimensions((800, 600), (400, 500)), (667, 500));
+        assert_eq!(
+            calculate_fill_dimensions((800, 600), (400, 500)),
+            (667, 500)
+        );
     }
 
     #[test]
     fn fill_taller_source_to_landscape_target() {
         // 600x800 (3:4) → 500x400 target
         // Source is taller, so width matches: 500, height = 500 * (4/3) = 667
-        assert_eq!(calculate_fill_dimensions((600, 800), (500, 400)), (500, 667));
+        assert_eq!(
+            calculate_fill_dimensions((600, 800), (500, 400)),
+            (500, 667)
+        );
     }
 
     #[test]
     fn fill_same_aspect_ratio() {
         // 800x600 (4:3) → 400x300 target (also 4:3)
         // Perfect match
-        assert_eq!(calculate_fill_dimensions((800, 600), (400, 300)), (400, 300));
+        assert_eq!(
+            calculate_fill_dimensions((800, 600), (400, 300)),
+            (400, 300)
+        );
     }
 
     #[test]
     fn fill_square_source_to_portrait() {
         // 400x400 (1:1) → 200x300 target
         // Source is wider (1:1 > 2:3), height matches: 300, width = 300
-        assert_eq!(calculate_fill_dimensions((400, 400), (200, 300)), (300, 300));
+        assert_eq!(
+            calculate_fill_dimensions((400, 400), (200, 300)),
+            (300, 300)
+        );
     }
 
     // =========================================================================

--- a/src/imaging/mod.rs
+++ b/src/imaging/mod.rs
@@ -1,0 +1,18 @@
+//! Image processing abstraction layer.
+//!
+//! This module provides a clean separation between:
+//! - **Calculations**: Pure functions for dimension math (unit testable)
+//! - **Parameters**: Data structures describing image operations
+//! - **Backend**: Trait + implementation for actual image processing
+//! - **Operations**: High-level functions combining calculations + backend
+
+pub mod backend;
+mod calculations;
+pub mod operations;
+mod params;
+
+pub use backend::{BackendError, Dimensions, ImageBackend, ImageMagickBackend};
+pub use operations::{
+    create_responsive_images, create_thumbnail, get_dimensions, ResponsiveConfig, ThumbnailConfig,
+};
+pub use params::{Quality, Sharpening};

--- a/src/imaging/mod.rs
+++ b/src/imaging/mod.rs
@@ -11,7 +11,10 @@ mod calculations;
 pub mod operations;
 mod params;
 
-pub use backend::{BackendError, Dimensions, ImageBackend, ImageMagickBackend};
+pub use backend::{BackendError, ImageBackend, ImageMagickBackend};
+// Re-exported for tests (process.rs, operations.rs tests use this)
+#[cfg(test)]
+pub use backend::Dimensions;
 pub use operations::{
     ResponsiveConfig, ThumbnailConfig, create_responsive_images, create_thumbnail, get_dimensions,
 };

--- a/src/imaging/mod.rs
+++ b/src/imaging/mod.rs
@@ -13,6 +13,6 @@ mod params;
 
 pub use backend::{BackendError, Dimensions, ImageBackend, ImageMagickBackend};
 pub use operations::{
-    create_responsive_images, create_thumbnail, get_dimensions, ResponsiveConfig, ThumbnailConfig,
+    ResponsiveConfig, ThumbnailConfig, create_responsive_images, create_thumbnail, get_dimensions,
 };
 pub use params::{Quality, Sharpening};

--- a/src/imaging/operations.rs
+++ b/src/imaging/operations.rs
@@ -1,0 +1,341 @@
+//! High-level image operations.
+//!
+//! These functions combine calculations with backend execution.
+//! They take configuration, compute parameters, and call the backend.
+
+use super::backend::{BackendError, ImageBackend};
+use super::calculations::{
+    calculate_fill_dimensions, calculate_responsive_sizes, calculate_thumbnail_dimensions,
+    ResponsiveSize,
+};
+use super::params::{Quality, ResizeParams, Sharpening, ThumbnailParams};
+use std::path::Path;
+
+/// Result type for image operations.
+pub type Result<T> = std::result::Result<T, BackendError>;
+
+/// Get image dimensions using the backend.
+pub fn get_dimensions(backend: &impl ImageBackend, path: &Path) -> Result<(u32, u32)> {
+    let dims = backend.identify(path)?;
+    Ok((dims.width, dims.height))
+}
+
+/// Generated image variant with paths and dimensions.
+#[derive(Debug, Clone)]
+pub struct GeneratedVariant {
+    pub target_size: u32,
+    pub avif_path: String,
+    pub webp_path: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Configuration for responsive image generation.
+#[derive(Debug, Clone)]
+pub struct ResponsiveConfig {
+    pub sizes: Vec<u32>,
+    pub quality: Quality,
+}
+
+/// Create responsive images at multiple sizes.
+///
+/// Generates AVIF and WebP variants for each applicable size.
+/// Sizes larger than the original are skipped.
+pub fn create_responsive_images(
+    backend: &impl ImageBackend,
+    source: &Path,
+    output_dir: &Path,
+    filename_stem: &str,
+    original_dims: (u32, u32),
+    config: &ResponsiveConfig,
+) -> Result<Vec<GeneratedVariant>> {
+    let sizes = calculate_responsive_sizes(original_dims, &config.sizes);
+    let mut variants = Vec::new();
+
+    for ResponsiveSize {
+        target,
+        width,
+        height,
+    } in sizes
+    {
+        let avif_name = format!("{}-{}.avif", filename_stem, target);
+        let webp_name = format!("{}-{}.webp", filename_stem, target);
+        let avif_path = output_dir.join(&avif_name);
+        let webp_path = output_dir.join(&webp_name);
+
+        // Generate AVIF
+        backend.resize(&ResizeParams {
+            source: source.to_path_buf(),
+            output: avif_path.clone(),
+            width,
+            height,
+            quality: config.quality,
+        })?;
+
+        // Generate WebP
+        backend.resize(&ResizeParams {
+            source: source.to_path_buf(),
+            output: webp_path.clone(),
+            width,
+            height,
+            quality: config.quality,
+        })?;
+
+        // Compute relative path for manifest
+        let relative_dir = output_dir
+            .file_name()
+            .map(|s| s.to_str().unwrap())
+            .unwrap_or("");
+
+        variants.push(GeneratedVariant {
+            target_size: target,
+            avif_path: format!("{}/{}", relative_dir, avif_name),
+            webp_path: format!("{}/{}", relative_dir, webp_name),
+            width,
+            height,
+        });
+    }
+
+    Ok(variants)
+}
+
+/// Configuration for thumbnail generation.
+#[derive(Debug, Clone)]
+pub struct ThumbnailConfig {
+    pub aspect: (u32, u32),
+    pub short_edge: u32,
+    pub quality: Quality,
+    pub sharpening: Option<Sharpening>,
+}
+
+impl Default for ThumbnailConfig {
+    fn default() -> Self {
+        Self {
+            aspect: (4, 5),
+            short_edge: 400,
+            quality: Quality::default(),
+            sharpening: Some(Sharpening::light()),
+        }
+    }
+}
+
+/// Plan a thumbnail operation without executing it.
+///
+/// Useful for testing parameter generation.
+pub fn plan_thumbnail(
+    source: &Path,
+    output_path: &Path,
+    source_dims: (u32, u32),
+    config: &ThumbnailConfig,
+) -> ThumbnailParams {
+    let (crop_w, crop_h) = calculate_thumbnail_dimensions(config.aspect, config.short_edge);
+    let (fill_w, fill_h) = calculate_fill_dimensions(source_dims, (crop_w, crop_h));
+
+    ThumbnailParams {
+        source: source.to_path_buf(),
+        output: output_path.to_path_buf(),
+        fill_width: fill_w,
+        fill_height: fill_h,
+        crop_width: crop_w,
+        crop_height: crop_h,
+        quality: config.quality,
+        sharpening: config.sharpening,
+    }
+}
+
+/// Create a thumbnail image.
+///
+/// Resizes to fill the target aspect ratio, then center-crops.
+pub fn create_thumbnail(
+    backend: &impl ImageBackend,
+    source: &Path,
+    output_dir: &Path,
+    filename_stem: &str,
+    source_dims: (u32, u32),
+    config: &ThumbnailConfig,
+) -> Result<String> {
+    let thumb_name = format!("{}-thumb.webp", filename_stem);
+    let thumb_path = output_dir.join(&thumb_name);
+
+    let params = plan_thumbnail(source, &thumb_path, source_dims, config);
+    backend.thumbnail(&params)?;
+
+    let relative_dir = output_dir
+        .file_name()
+        .map(|s| s.to_str().unwrap())
+        .unwrap_or("");
+
+    Ok(format!("{}/{}", relative_dir, thumb_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imaging::backend::tests::{MockBackend, RecordedOp};
+    use crate::imaging::Dimensions;
+
+    #[test]
+    fn get_dimensions_calls_backend() {
+        let backend = MockBackend::with_dimensions(vec![Dimensions {
+            width: 1920,
+            height: 1080,
+        }]);
+
+        let dims = get_dimensions(&backend, Path::new("/test.jpg")).unwrap();
+        assert_eq!(dims, (1920, 1080));
+    }
+
+    #[test]
+    fn plan_thumbnail_calculates_fill_and_crop() {
+        // 800x600 landscape source → 4:5 portrait thumb at 400 short edge
+        // Crop target: 400x500
+        // Fill: source is wider (4:3 > 4:5), so height matches
+        // Fill height = 500, width = 500 * (800/600) = 667
+        let params = plan_thumbnail(
+            Path::new("/source.jpg"),
+            Path::new("/thumb.webp"),
+            (800, 600),
+            &ThumbnailConfig::default(),
+        );
+
+        assert_eq!(params.crop_width, 400);
+        assert_eq!(params.crop_height, 500);
+        assert_eq!(params.fill_width, 667);
+        assert_eq!(params.fill_height, 500);
+    }
+
+    #[test]
+    fn plan_thumbnail_with_portrait_source() {
+        // 600x800 portrait source → 4:5 portrait thumb at 400 short edge
+        // Crop target: 400x500
+        // Source is 3:4 = 0.75, target is 4:5 = 0.8
+        // Source is taller (0.75 < 0.8), so width matches
+        // Fill width = 400, height = 400 / 0.75 = 533
+        let params = plan_thumbnail(
+            Path::new("/source.jpg"),
+            Path::new("/thumb.webp"),
+            (600, 800),
+            &ThumbnailConfig::default(),
+        );
+
+        assert_eq!(params.crop_width, 400);
+        assert_eq!(params.crop_height, 500);
+        assert_eq!(params.fill_width, 400);
+        assert_eq!(params.fill_height, 533);
+    }
+
+    #[test]
+    fn create_thumbnail_uses_backend() {
+        let backend = MockBackend::new();
+        let config = ThumbnailConfig::default();
+
+        let result = create_thumbnail(
+            &backend,
+            Path::new("/source.jpg"),
+            Path::new("/output"),
+            "001-test",
+            (800, 600),
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(result, "output/001-test-thumb.webp");
+
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(
+            &ops[0],
+            RecordedOp::Thumbnail {
+                crop_width: 400,
+                crop_height: 500,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn create_responsive_skips_larger_sizes() {
+        let backend = MockBackend::new();
+        let config = ResponsiveConfig {
+            sizes: vec![800, 1400, 2080],
+            quality: Quality::default(),
+        };
+
+        // Original is 1000px - should skip 1400 and 2080
+        let variants = create_responsive_images(
+            &backend,
+            Path::new("/source.jpg"),
+            Path::new("/output"),
+            "001-test",
+            (1000, 750),
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0].target_size, 800);
+
+        // Should have 2 operations (AVIF + WebP)
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 2);
+    }
+
+    #[test]
+    fn create_responsive_generates_all_formats() {
+        let backend = MockBackend::new();
+        let config = ResponsiveConfig {
+            sizes: vec![800],
+            quality: Quality::new(85),
+        };
+
+        create_responsive_images(
+            &backend,
+            Path::new("/source.jpg"),
+            Path::new("/output"),
+            "001-test",
+            (2000, 1500),
+            &config,
+        )
+        .unwrap();
+
+        let ops = backend.get_operations();
+        assert_eq!(ops.len(), 2);
+
+        // First should be AVIF
+        assert!(matches!(
+            &ops[0],
+            RecordedOp::Resize { output, quality: 85, .. } if output.ends_with(".avif")
+        ));
+
+        // Second should be WebP
+        assert!(matches!(
+            &ops[1],
+            RecordedOp::Resize { output, quality: 85, .. } if output.ends_with(".webp")
+        ));
+    }
+
+    #[test]
+    fn create_responsive_fallback_to_original_size() {
+        let backend = MockBackend::new();
+        let config = ResponsiveConfig {
+            sizes: vec![800, 1400],
+            quality: Quality::default(),
+        };
+
+        // Original is only 500px - smaller than all targets
+        let variants = create_responsive_images(
+            &backend,
+            Path::new("/source.jpg"),
+            Path::new("/output"),
+            "001-test",
+            (500, 400),
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0].target_size, 500); // Uses original size
+        assert_eq!(variants[0].width, 500);
+        assert_eq!(variants[0].height, 400);
+    }
+}

--- a/src/imaging/operations.rs
+++ b/src/imaging/operations.rs
@@ -5,8 +5,8 @@
 
 use super::backend::{BackendError, ImageBackend};
 use super::calculations::{
-    calculate_fill_dimensions, calculate_responsive_sizes, calculate_thumbnail_dimensions,
-    ResponsiveSize,
+    ResponsiveSize, calculate_fill_dimensions, calculate_responsive_sizes,
+    calculate_thumbnail_dimensions,
 };
 use super::params::{Quality, ResizeParams, Sharpening, ThumbnailParams};
 use std::path::Path;
@@ -171,8 +171,8 @@ pub fn create_thumbnail(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::imaging::backend::tests::{MockBackend, RecordedOp};
     use crate::imaging::Dimensions;
+    use crate::imaging::backend::tests::{MockBackend, RecordedOp};
 
     #[test]
     fn get_dimensions_calls_backend() {

--- a/src/imaging/params.rs
+++ b/src/imaging/params.rs
@@ -1,0 +1,92 @@
+//! Parameter types for image operations.
+//!
+//! These structs describe what to do, not how to do it.
+//! The backend interprets these and executes the actual commands.
+
+use std::path::PathBuf;
+
+/// Quality setting for lossy image encoding (1-100).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Quality(pub u32);
+
+impl Quality {
+    pub fn new(value: u32) -> Self {
+        Self(value.clamp(1, 100))
+    }
+
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for Quality {
+    fn default() -> Self {
+        Self(90)
+    }
+}
+
+/// Sharpening parameters (radius, sigma).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Sharpening {
+    pub radius: f32,
+    pub sigma: f32,
+}
+
+impl Sharpening {
+    /// Light sharpening suitable for thumbnails.
+    pub fn light() -> Self {
+        Self {
+            radius: 0.0,
+            sigma: 0.5,
+        }
+    }
+}
+
+/// Parameters for a simple resize operation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResizeParams {
+    pub source: PathBuf,
+    pub output: PathBuf,
+    pub width: u32,
+    pub height: u32,
+    pub quality: Quality,
+}
+
+/// Parameters for a thumbnail operation (resize + center crop).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThumbnailParams {
+    pub source: PathBuf,
+    pub output: PathBuf,
+    /// Fill dimensions (may exceed final size).
+    pub fill_width: u32,
+    pub fill_height: u32,
+    /// Final crop dimensions.
+    pub crop_width: u32,
+    pub crop_height: u32,
+    pub quality: Quality,
+    pub sharpening: Option<Sharpening>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_clamps_to_valid_range() {
+        assert_eq!(Quality::new(0).value(), 1);
+        assert_eq!(Quality::new(50).value(), 50);
+        assert_eq!(Quality::new(150).value(), 100);
+    }
+
+    #[test]
+    fn quality_default_is_90() {
+        assert_eq!(Quality::default().value(), 90);
+    }
+
+    #[test]
+    fn sharpening_light_values() {
+        let s = Sharpening::light();
+        assert_eq!(s.radius, 0.0);
+        assert_eq!(s.sigma, 0.5);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@
 
 mod config;
 mod generate;
+mod imaging;
 mod process;
 mod scan;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,39 @@
+//! # LightTable
+//!
+//! A minimal static site generator for fine art photography portfolios.
+//!
+//! ## Build Pipeline
+//!
+//! LightTable processes images through a three-stage pipeline:
+//!
+//! ```text
+//! 1. Scan      →  manifest.json    (filesystem → structured data)
+//! 2. Process   →  processed/       (responsive sizes + thumbnails)
+//! 3. Generate  →  dist/            (final HTML site)
+//! ```
+//!
+//! Each stage is independent and produces a manifest file that the next stage consumes.
+//! This allows incremental builds and easy debugging.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # Full build (recommended)
+//! lighttable build ./images --output ./dist
+//!
+//! # Or run stages individually
+//! lighttable scan ./images
+//! lighttable process manifest.json --output processed
+//! lighttable generate processed/manifest.json --output dist
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`config`] - Site configuration loaded from `config.toml`
+//! - [`scan`] - Stage 1: Filesystem scanning and manifest generation
+//! - [`process`] - Stage 2: Image processing (responsive sizes, thumbnails)
+//! - [`generate`] - Stage 3: HTML site generation
+
 mod config;
 mod generate;
 mod process;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod generate;
 mod process;
 mod scan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("==> Stage 2: Processing images");
             let processed_dir = temp_dir.join("processed");
             let config = process::ProcessConfig::default();
-            let processed_manifest = process::process(&scan_manifest_path, &root, &processed_dir, &config)?;
+            let processed_manifest =
+                process::process(&scan_manifest_path, &root, &processed_dir, &config)?;
             let processed_manifest_path = processed_dir.join("manifest.json");
             let json = serde_json::to_string_pretty(&processed_manifest)?;
             std::fs::write(&processed_manifest_path, &json)?;

--- a/src/process.rs
+++ b/src/process.rs
@@ -45,8 +45,8 @@
 
 use crate::config::SiteConfig;
 use crate::imaging::{
-    create_responsive_images, create_thumbnail, get_dimensions, BackendError, ImageBackend,
-    ImageMagickBackend, Quality, ResponsiveConfig, Sharpening, ThumbnailConfig,
+    BackendError, ImageBackend, ImageMagickBackend, Quality, ResponsiveConfig, Sharpening,
+    ThumbnailConfig, create_responsive_images, create_thumbnail, get_dimensions,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -468,8 +468,8 @@ mod tests {
     // Process with mock backend tests (no ImageMagick required)
     // =========================================================================
 
-    use crate::imaging::backend::tests::MockBackend;
     use crate::imaging::Dimensions;
+    use crate::imaging::backend::tests::MockBackend;
 
     fn create_test_manifest(tmp: &Path) -> PathBuf {
         let manifest = r##"{

--- a/src/process.rs
+++ b/src/process.rs
@@ -39,7 +39,11 @@ impl Default for ProcessConfig {
 /// About page content
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AboutPage {
+    /// Title from markdown content (first # heading)
     pub title: String,
+    /// Link title from filename (dashes to spaces)
+    pub link_title: String,
+    /// Raw markdown body content
     pub body: String,
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,9 +5,7 @@
 //!
 //! ## Dependencies
 //!
-//! Requires ImageMagick to be installed:
-//! - **ImageMagick 7** (preferred): Uses the `magick` command
-//! - **ImageMagick 6** (fallback): Uses the `convert` command
+//! Requires ImageMagick to be installed. Uses the `convert` and `identify` commands.
 //!
 //! ## Output Formats
 //!
@@ -46,10 +44,12 @@
 //! optimal performance on multi-core systems.
 
 use crate::config::SiteConfig;
-use rayon::prelude::*;
+use crate::imaging::{
+    create_responsive_images, create_thumbnail, get_dimensions, BackendError, ImageBackend,
+    ImageMagickBackend, Quality, ResponsiveConfig, Sharpening, ThumbnailConfig,
+};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -58,8 +58,8 @@ pub enum ProcessError {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("ImageMagick failed: {0}")]
-    ImageMagick(String),
+    #[error("Image processing failed: {0}")]
+    Imaging(#[from] BackendError),
     #[error("Source image not found: {0}")]
     SourceNotFound(PathBuf),
 }
@@ -177,10 +177,34 @@ pub fn process(
     output_dir: &Path,
     config: &ProcessConfig,
 ) -> Result<OutputManifest, ProcessError> {
+    let backend = ImageMagickBackend::new();
+    process_with_backend(&backend, manifest_path, source_root, output_dir, config)
+}
+
+/// Process images using a specific backend (allows testing with mock).
+pub fn process_with_backend(
+    backend: &impl ImageBackend,
+    manifest_path: &Path,
+    source_root: &Path,
+    output_dir: &Path,
+    config: &ProcessConfig,
+) -> Result<OutputManifest, ProcessError> {
     let manifest_content = std::fs::read_to_string(manifest_path)?;
     let input: InputManifest = serde_json::from_str(&manifest_content)?;
 
     std::fs::create_dir_all(output_dir)?;
+
+    let responsive_config = ResponsiveConfig {
+        sizes: config.sizes.clone(),
+        quality: Quality::new(config.quality),
+    };
+
+    let thumbnail_config = ThumbnailConfig {
+        aspect: config.thumbnail_aspect,
+        short_edge: config.thumbnail_size,
+        quality: Quality::new(config.quality),
+        sharpening: Some(Sharpening::light()),
+    };
 
     let mut output_albums = Vec::new();
 
@@ -189,39 +213,65 @@ pub fn process(
         let album_output_dir = output_dir.join(&album.path);
         std::fs::create_dir_all(&album_output_dir)?;
 
-        // Process images in parallel
-        let results: Result<Vec<_>, _> = album
-            .images
-            .par_iter()
-            .map(|image| {
-                let source_path = source_root.join(&image.source_path);
-                if !source_path.exists() {
-                    return Err(ProcessError::SourceNotFound(source_path));
-                }
+        // Process images (sequentially when using backend reference)
+        let mut processed_images = Vec::new();
 
-                println!("  {} ", image.filename);
+        for image in &album.images {
+            let source_path = source_root.join(&image.source_path);
+            if !source_path.exists() {
+                return Err(ProcessError::SourceNotFound(source_path));
+            }
 
-                // Get original dimensions
-                let dimensions = get_dimensions(&source_path)?;
+            println!("  {} ", image.filename);
 
-                // Generate responsive sizes
-                let generated = generate_responsive_images(
-                    &source_path,
-                    &album_output_dir,
-                    &image.filename,
-                    dimensions,
-                    config,
-                )?;
+            // Get original dimensions
+            let dimensions = get_dimensions(backend, &source_path)?;
 
-                // Generate thumbnail
-                let thumbnail_path =
-                    generate_thumbnail(&source_path, &album_output_dir, &image.filename, config)?;
+            // Get filename stem
+            let stem = Path::new(&image.filename)
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap();
 
-                Ok((image, dimensions, generated, thumbnail_path))
-            })
-            .collect();
+            // Generate responsive sizes
+            let variants = create_responsive_images(
+                backend,
+                &source_path,
+                &album_output_dir,
+                stem,
+                dimensions,
+                &responsive_config,
+            )?;
 
-        let processed_images = results?;
+            // Generate thumbnail
+            let thumbnail_path = create_thumbnail(
+                backend,
+                &source_path,
+                &album_output_dir,
+                stem,
+                dimensions,
+                &thumbnail_config,
+            )?;
+
+            // Convert variants to BTreeMap
+            let generated: std::collections::BTreeMap<String, GeneratedVariant> = variants
+                .into_iter()
+                .map(|v| {
+                    (
+                        v.target_size.to_string(),
+                        GeneratedVariant {
+                            avif: v.avif_path,
+                            webp: v.webp_path,
+                            width: v.width,
+                            height: v.height,
+                        },
+                    )
+                })
+                .collect();
+
+            processed_images.push((image, dimensions, generated, thumbnail_path));
+        }
 
         // Build output images (preserving order)
         let mut output_images: Vec<OutputImage> = processed_images
@@ -265,238 +315,6 @@ pub fn process(
         about: input.about,
         config: input.config,
     })
-}
-
-fn get_dimensions(path: &Path) -> Result<(u32, u32), ProcessError> {
-    let cmd = get_imagemagick_command();
-    let args = if cmd == "magick" {
-        vec!["identify", "-format", "%w %h", path.to_str().unwrap()]
-    } else {
-        vec!["-format", "%w %h", path.to_str().unwrap()]
-    };
-    // Use identify command for dimensions
-    let output = Command::new(if cmd == "magick" {
-        "magick"
-    } else {
-        "identify"
-    })
-    .args(&args)
-    .output()?;
-
-    if !output.status.success() {
-        return Err(ProcessError::ImageMagick(
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ));
-    }
-
-    let dims = String::from_utf8_lossy(&output.stdout);
-    let parts: Vec<&str> = dims.split_whitespace().collect();
-    if parts.len() != 2 {
-        return Err(ProcessError::ImageMagick(format!(
-            "Unexpected identify output: {}",
-            dims
-        )));
-    }
-
-    let width: u32 = parts[0]
-        .parse()
-        .map_err(|_| ProcessError::ImageMagick(format!("Invalid width: {}", parts[0])))?;
-    let height: u32 = parts[1]
-        .parse()
-        .map_err(|_| ProcessError::ImageMagick(format!("Invalid height: {}", parts[1])))?;
-
-    Ok((width, height))
-}
-
-fn generate_responsive_images(
-    source: &Path,
-    output_dir: &Path,
-    filename: &str,
-    dimensions: (u32, u32),
-    config: &ProcessConfig,
-) -> Result<std::collections::BTreeMap<String, GeneratedVariant>, ProcessError> {
-    let mut generated = std::collections::BTreeMap::new();
-    let stem = Path::new(filename).file_stem().unwrap().to_str().unwrap();
-
-    let (orig_w, orig_h) = dimensions;
-    let longer_edge = orig_w.max(orig_h);
-
-    for &target_size in &config.sizes {
-        // Skip sizes larger than original
-        if target_size > longer_edge {
-            continue;
-        }
-
-        // Calculate output dimensions (preserve aspect ratio)
-        let (out_w, out_h) = if orig_w >= orig_h {
-            let ratio = target_size as f64 / orig_w as f64;
-            (target_size, (orig_h as f64 * ratio).round() as u32)
-        } else {
-            let ratio = target_size as f64 / orig_h as f64;
-            ((orig_w as f64 * ratio).round() as u32, target_size)
-        };
-
-        let avif_name = format!("{}-{}.avif", stem, target_size);
-        let webp_name = format!("{}-{}.webp", stem, target_size);
-        let avif_path = output_dir.join(&avif_name);
-        let webp_path = output_dir.join(&webp_name);
-
-        // Generate AVIF
-        run_magick(&[
-            source.to_str().unwrap(),
-            "-resize",
-            &format!("{}x{}", out_w, out_h),
-            "-quality",
-            &config.quality.to_string(),
-            "-define",
-            "heic:speed=6", // Faster encoding
-            avif_path.to_str().unwrap(),
-        ])?;
-
-        // Generate WebP
-        run_magick(&[
-            source.to_str().unwrap(),
-            "-resize",
-            &format!("{}x{}", out_w, out_h),
-            "-quality",
-            &config.quality.to_string(),
-            webp_path.to_str().unwrap(),
-        ])?;
-
-        let relative_dir = output_dir
-            .file_name()
-            .map(|s| s.to_str().unwrap())
-            .unwrap_or("");
-
-        generated.insert(
-            target_size.to_string(),
-            GeneratedVariant {
-                avif: format!("{}/{}", relative_dir, avif_name),
-                webp: format!("{}/{}", relative_dir, webp_name),
-                width: out_w,
-                height: out_h,
-            },
-        );
-    }
-
-    // If original is smaller than smallest target, use original size
-    if generated.is_empty() {
-        let avif_name = format!("{}-{}.avif", stem, longer_edge);
-        let webp_name = format!("{}-{}.webp", stem, longer_edge);
-        let avif_path = output_dir.join(&avif_name);
-        let webp_path = output_dir.join(&webp_name);
-
-        run_magick(&[
-            source.to_str().unwrap(),
-            "-quality",
-            &config.quality.to_string(),
-            avif_path.to_str().unwrap(),
-        ])?;
-
-        run_magick(&[
-            source.to_str().unwrap(),
-            "-quality",
-            &config.quality.to_string(),
-            webp_path.to_str().unwrap(),
-        ])?;
-
-        let relative_dir = output_dir
-            .file_name()
-            .map(|s| s.to_str().unwrap())
-            .unwrap_or("");
-
-        generated.insert(
-            longer_edge.to_string(),
-            GeneratedVariant {
-                avif: format!("{}/{}", relative_dir, avif_name),
-                webp: format!("{}/{}", relative_dir, webp_name),
-                width: orig_w,
-                height: orig_h,
-            },
-        );
-    }
-
-    Ok(generated)
-}
-
-fn generate_thumbnail(
-    source: &Path,
-    output_dir: &Path,
-    filename: &str,
-    config: &ProcessConfig,
-) -> Result<String, ProcessError> {
-    let stem = Path::new(filename).file_stem().unwrap().to_str().unwrap();
-    let (aspect_w, aspect_h) = config.thumbnail_aspect;
-
-    // Calculate thumbnail dimensions based on aspect ratio
-    // If aspect is 4:5 (portrait), width is short edge
-    let (thumb_w, thumb_h) = if aspect_w <= aspect_h {
-        let w = config.thumbnail_size;
-        let h = (w as f64 * aspect_h as f64 / aspect_w as f64).round() as u32;
-        (w, h)
-    } else {
-        let h = config.thumbnail_size;
-        let w = (h as f64 * aspect_w as f64 / aspect_h as f64).round() as u32;
-        (w, h)
-    };
-
-    let thumb_name = format!("{}-thumb.webp", stem);
-    let thumb_path = output_dir.join(&thumb_name);
-
-    // Use ImageMagick to resize and crop to fill the thumbnail
-    // -resize WxH^ resizes to fill (may exceed dimensions)
-    // -gravity center -extent WxH crops to exact size
-    run_magick(&[
-        source.to_str().unwrap(),
-        "-resize",
-        &format!("{}x{}^", thumb_w, thumb_h),
-        "-gravity",
-        "center",
-        "-extent",
-        &format!("{}x{}", thumb_w, thumb_h),
-        "-quality",
-        &config.quality.to_string(),
-        "-sharpen",
-        "0x0.5", // Light sharpening for thumbnails
-        thumb_path.to_str().unwrap(),
-    ])?;
-
-    let relative_dir = output_dir
-        .file_name()
-        .map(|s| s.to_str().unwrap())
-        .unwrap_or("");
-
-    Ok(format!("{}/{}", relative_dir, thumb_name))
-}
-
-fn get_imagemagick_command() -> &'static str {
-    use std::sync::OnceLock;
-    static CMD: OnceLock<&str> = OnceLock::new();
-    CMD.get_or_init(|| {
-        // Prefer magick (ImageMagick 7) but fall back to convert (ImageMagick 6)
-        if Command::new("magick")
-            .arg("-version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-        {
-            "magick"
-        } else {
-            "convert"
-        }
-    })
-}
-
-fn run_magick(args: &[&str]) -> Result<(), ProcessError> {
-    let cmd = get_imagemagick_command();
-    let output = Command::new(cmd).args(args).output()?;
-
-    if !output.status.success() {
-        return Err(ProcessError::ImageMagick(
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -647,8 +465,11 @@ mod tests {
     }
 
     // =========================================================================
-    // ImageMagick integration tests (require magick command)
+    // Process with mock backend tests (no ImageMagick required)
     // =========================================================================
+
+    use crate::imaging::backend::tests::MockBackend;
+    use crate::imaging::Dimensions;
 
     fn create_test_manifest(tmp: &Path) -> PathBuf {
         let manifest = r##"{
@@ -692,10 +513,153 @@ mod tests {
         manifest_path
     }
 
+    fn create_dummy_source(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Just create an empty file - the mock backend doesn't need real content
+        fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn process_with_mock_generates_correct_outputs() {
+        let tmp = TempDir::new().unwrap();
+        let source_dir = tmp.path().join("source");
+        let output_dir = tmp.path().join("output");
+
+        // Create dummy source file
+        let image_path = source_dir.join("test-album/001-test.jpg");
+        create_dummy_source(&image_path);
+
+        // Create manifest
+        let manifest_path = create_test_manifest(tmp.path());
+
+        // Create mock backend with dimensions
+        let backend = MockBackend::with_dimensions(vec![Dimensions {
+            width: 200,
+            height: 250,
+        }]);
+
+        // Process
+        let config = ProcessConfig {
+            sizes: vec![100, 150],
+            thumbnail_size: 80,
+            ..Default::default()
+        };
+
+        let result =
+            process_with_backend(&backend, &manifest_path, &source_dir, &output_dir, &config)
+                .unwrap();
+
+        // Verify outputs
+        assert_eq!(result.albums.len(), 1);
+        assert_eq!(result.albums[0].images.len(), 1);
+
+        let image = &result.albums[0].images[0];
+        assert_eq!(image.dimensions, (200, 250));
+        assert!(!image.generated.is_empty());
+        assert!(!image.thumbnail.is_empty());
+    }
+
+    #[test]
+    fn process_with_mock_records_correct_operations() {
+        let tmp = TempDir::new().unwrap();
+        let source_dir = tmp.path().join("source");
+        let output_dir = tmp.path().join("output");
+
+        let image_path = source_dir.join("test-album/001-test.jpg");
+        create_dummy_source(&image_path);
+
+        let manifest_path = create_test_manifest(tmp.path());
+
+        // 2000x1500 landscape - should generate both sizes
+        let backend = MockBackend::with_dimensions(vec![Dimensions {
+            width: 2000,
+            height: 1500,
+        }]);
+
+        let config = ProcessConfig {
+            sizes: vec![800, 1400],
+            quality: 85,
+            thumbnail_size: 100,
+            ..Default::default()
+        };
+
+        process_with_backend(&backend, &manifest_path, &source_dir, &output_dir, &config).unwrap();
+
+        use crate::imaging::backend::tests::RecordedOp;
+        let ops = backend.get_operations();
+
+        // Should have: 1 identify + 4 resizes (2 sizes × 2 formats) + 1 thumbnail = 6 ops
+        assert_eq!(ops.len(), 6);
+
+        // First is identify
+        assert!(matches!(&ops[0], RecordedOp::Identify(_)));
+
+        // Then resizes with correct quality
+        for op in &ops[1..5] {
+            assert!(matches!(op, RecordedOp::Resize { quality: 85, .. }));
+        }
+
+        // Last is thumbnail
+        assert!(matches!(&ops[5], RecordedOp::Thumbnail { .. }));
+    }
+
+    #[test]
+    fn process_with_mock_skips_larger_sizes() {
+        let tmp = TempDir::new().unwrap();
+        let source_dir = tmp.path().join("source");
+        let output_dir = tmp.path().join("output");
+
+        let image_path = source_dir.join("test-album/001-test.jpg");
+        create_dummy_source(&image_path);
+
+        let manifest_path = create_test_manifest(tmp.path());
+
+        // 500x400 - smaller than all requested sizes
+        let backend = MockBackend::with_dimensions(vec![Dimensions {
+            width: 500,
+            height: 400,
+        }]);
+
+        let config = ProcessConfig {
+            sizes: vec![800, 1400, 2080],
+            ..Default::default()
+        };
+
+        let result =
+            process_with_backend(&backend, &manifest_path, &source_dir, &output_dir, &config)
+                .unwrap();
+
+        // Should only have original size
+        let image = &result.albums[0].images[0];
+        assert_eq!(image.generated.len(), 1);
+        assert!(image.generated.contains_key("500"));
+    }
+
+    #[test]
+    fn process_source_not_found_error() {
+        let tmp = TempDir::new().unwrap();
+        let source_dir = tmp.path().join("source");
+        let output_dir = tmp.path().join("output");
+
+        // Don't create the source file
+        let manifest_path = create_test_manifest(tmp.path());
+        let backend = MockBackend::new();
+        let config = ProcessConfig::default();
+
+        let result =
+            process_with_backend(&backend, &manifest_path, &source_dir, &output_dir, &config);
+
+        assert!(matches!(result, Err(ProcessError::SourceNotFound(_))));
+    }
+
+    // =========================================================================
+    // ImageMagick integration tests (require ImageMagick)
+    // =========================================================================
+
     fn create_test_image(path: &Path) {
         // Create a 200x250 test image (4:5 aspect)
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        Command::new("magick")
+        std::process::Command::new("convert")
             .args([
                 "-size",
                 "200x250",
@@ -769,7 +733,8 @@ mod tests {
 
         // Check thumbnail dimensions
         let thumb_path = output_dir.join("test-album/001-test-thumb.webp");
-        let dims = get_dimensions(&thumb_path).unwrap();
+        let backend = ImageMagickBackend::new();
+        let dims = crate::imaging::get_dimensions(&backend, &thumb_path).unwrap();
 
         // Should be 80x100 (4:5 with short edge 80)
         assert_eq!(dims, (80, 100));

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,3 +1,50 @@
+//! Image processing and responsive image generation.
+//!
+//! Stage 2 of the LightTable build pipeline. Takes the manifest from the scan stage
+//! and processes all images to generate responsive sizes and thumbnails.
+//!
+//! ## Dependencies
+//!
+//! Requires ImageMagick to be installed:
+//! - **ImageMagick 7** (preferred): Uses the `magick` command
+//! - **ImageMagick 6** (fallback): Uses the `convert` command
+//!
+//! ## Output Formats
+//!
+//! For each source image, generates:
+//! - **Responsive images**: Multiple sizes in AVIF and WebP formats
+//! - **Thumbnails**: Fixed aspect ratio crops for gallery grids
+//!
+//! ## Default Configuration
+//!
+//! ```text
+//! Responsive sizes: 800px, 1400px, 2080px (on the longer edge)
+//! Quality: 90%
+//! Thumbnail aspect: 4:5 (portrait)
+//! Thumbnail size: 400px (on the short edge)
+//! ```
+//!
+//! ## Output Structure
+//!
+//! ```text
+//! processed/
+//! ├── manifest.json              # Updated manifest with generated paths
+//! ├── 010-Landscapes/
+//! │   ├── 001-dawn-800.avif      # Responsive sizes
+//! │   ├── 001-dawn-800.webp
+//! │   ├── 001-dawn-1400.avif
+//! │   ├── 001-dawn-1400.webp
+//! │   ├── 001-dawn-2080.avif
+//! │   ├── 001-dawn-2080.webp
+//! │   └── 001-dawn-thumb.webp    # 4:5 center-cropped thumbnail
+//! └── ...
+//! ```
+//!
+//! ## Parallel Processing
+//!
+//! Images are processed in parallel using [rayon](https://docs.rs/rayon) for
+//! optimal performance on multi-core systems.
+
 use crate::config::SiteConfig;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,3 +1,4 @@
+use crate::config::SiteConfig;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -53,6 +54,7 @@ pub struct InputManifest {
     pub navigation: Vec<NavItem>,
     pub albums: Vec<InputAlbum>,
     pub about: Option<AboutPage>,
+    pub config: SiteConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -87,6 +89,7 @@ pub struct OutputManifest {
     pub albums: Vec<OutputAlbum>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub about: Option<AboutPage>,
+    pub config: SiteConfig,
 }
 
 #[derive(Debug, Serialize)]
@@ -215,6 +218,7 @@ pub fn process(
         navigation: input.navigation,
         albums: output_albums,
         about: input.about,
+        config: input.config,
     })
 }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -546,7 +546,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Requires ImageMagick
     fn mixed_content_is_error() {
         let tmp = TempDir::new().unwrap();
 
@@ -555,33 +554,23 @@ mod tests {
         fs::create_dir_all(&mixed).unwrap();
         fs::create_dir_all(mixed.join("subdir")).unwrap();
 
-        // Create a placeholder image in mixed dir
-        let img_path = mixed.join("001-photo.jpg");
-        std::process::Command::new("magick")
-            .args(["-size", "1x1", "xc:gray", img_path.to_str().unwrap()])
-            .output()
-            .unwrap();
+        // Create a placeholder image in mixed dir (scan only checks extension)
+        fs::write(mixed.join("001-photo.jpg"), "fake image").unwrap();
 
         let result = scan(tmp.path());
         assert!(matches!(result, Err(ScanError::MixedContent(_))));
     }
 
     #[test]
-    #[ignore] // Requires ImageMagick
     fn duplicate_number_is_error() {
         let tmp = TempDir::new().unwrap();
 
         let album = tmp.path().join("010-Album");
         fs::create_dir_all(&album).unwrap();
 
-        // Create two images with the same number
-        for name in ["001-first.jpg", "001-second.jpg"] {
-            let img_path = album.join(name);
-            std::process::Command::new("magick")
-                .args(["-size", "1x1", "xc:gray", img_path.to_str().unwrap()])
-                .output()
-                .unwrap();
-        }
+        // Create two images with the same number (scan only checks extension)
+        fs::write(album.join("001-first.jpg"), "fake image").unwrap();
+        fs::write(album.join("001-second.jpg"), "fake image").unwrap();
 
         let result = scan(tmp.path());
         assert!(matches!(result, Err(ScanError::DuplicateNumber(1, _))));

--- a/static/nav.js
+++ b/static/nav.js
@@ -6,6 +6,13 @@
     const prevUrl = zones.dataset.prev;
     const nextUrl = zones.dataset.next;
 
+    // Apply navigation direction class for view transitions
+    const navDirection = sessionStorage.getItem('nav-direction');
+    if (navDirection) {
+        document.documentElement.classList.add('nav-' + navDirection);
+        sessionStorage.removeItem('nav-direction');
+    }
+
     // Click navigation
     document.addEventListener('click', function(e) {
         // Ignore clicks on nav, links, etc.
@@ -13,20 +20,20 @@
 
         const x = e.clientX / window.innerWidth;
         if (x < 0.3) {
-            navigate(prevUrl);
+            navigate(prevUrl, 'back');
         } else if (x > 0.7) {
-            navigate(nextUrl);
+            navigate(nextUrl, 'forward');
         }
     });
 
     // Keyboard navigation
     document.addEventListener('keydown', function(e) {
         if (e.key === 'ArrowLeft' || e.key === 'h') {
-            navigate(prevUrl);
+            navigate(prevUrl, 'back');
         } else if (e.key === 'ArrowRight' || e.key === 'l') {
-            navigate(nextUrl);
+            navigate(nextUrl, 'forward');
         } else if (e.key === 'Escape') {
-            navigate('index.html');
+            navigate('index.html', 'back');
         }
     });
 
@@ -50,9 +57,9 @@
         // Only trigger if horizontal swipe is dominant
         if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 50) {
             if (deltaX > 0) {
-                navigate(prevUrl);
+                navigate(prevUrl, 'back');
             } else {
-                navigate(nextUrl);
+                navigate(nextUrl, 'forward');
             }
         }
     }, { passive: true });
@@ -70,8 +77,12 @@
     preload(prevUrl);
     preload(nextUrl);
 
-    function navigate(url) {
+    function navigate(url, direction) {
         if (url) {
+            // Store direction for the next page to pick up
+            if (direction) {
+                sessionStorage.setItem('nav-direction', direction);
+            }
             window.location.href = url;
         }
     }

--- a/static/style.css
+++ b/static/style.css
@@ -88,14 +88,8 @@
 }
 
 /* ===== CSS Custom Properties ===== */
+/* Note: Color variables (--color-*) are generated from config.toml */
 :root {
-    --color-bg: #ffffff;
-    --color-text: #111111;
-    --color-text-muted: #666666;
-    --color-border: #e0e0e0;
-    --color-link: #333333;
-    --color-link-hover: #000000;
-
     --frame-width: clamp(1rem, 3vw, 2.5rem);
     --header-height: 3rem;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -105,17 +99,6 @@
 
     --thumbnail-gap: 1rem;
     --transition-speed: 0.2s;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --color-bg: #0a0a0a;
-        --color-text: #eeeeee;
-        --color-text-muted: #999999;
-        --color-border: #333333;
-        --color-link: #cccccc;
-        --color-link-hover: #ffffff;
-    }
 }
 
 /* ===== Base ===== */

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,85 @@
 /* LightTable - Minimal Photo Gallery Styles */
 
+/* ===== View Transitions ===== */
+@view-transition {
+    navigation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation-duration: 0.25s;
+}
+
+/* Fade transition for page content */
+::view-transition-old(root) {
+    animation: fade-out 0.25s ease-out;
+}
+
+::view-transition-new(root) {
+    animation: fade-in 0.25s ease-in;
+}
+
+@keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Header stays in place during transitions */
+::view-transition-old(header),
+::view-transition-new(header) {
+    animation: none;
+}
+
+/* Main content slides and fades */
+::view-transition-old(main-content) {
+    animation: slide-out-left 0.25s ease-out;
+}
+
+::view-transition-new(main-content) {
+    animation: slide-in-right 0.25s ease-out;
+}
+
+@keyframes slide-out-left {
+    from { opacity: 1; transform: translateX(0); }
+    to { opacity: 0; transform: translateX(-20px); }
+}
+
+@keyframes slide-in-right {
+    from { opacity: 0; transform: translateX(20px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes slide-out-right {
+    from { opacity: 1; transform: translateX(0); }
+    to { opacity: 0; transform: translateX(20px); }
+}
+
+@keyframes slide-in-left {
+    from { opacity: 0; transform: translateX(-20px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+/* Reverse animation direction when navigating back */
+.nav-back::view-transition-old(main-content) {
+    animation: slide-out-right 0.25s ease-out;
+}
+
+.nav-back::view-transition-new(main-content) {
+    animation: slide-in-left 0.25s ease-out;
+}
+
+/* Disable transitions for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    @view-transition {
+        navigation: none;
+    }
+}
+
 /* ===== Reset ===== */
 *, *::before, *::after {
     box-sizing: border-box;
@@ -82,6 +162,7 @@ img {
     background: var(--color-bg);
     font-size: var(--font-size-small);
     z-index: 100;
+    view-transition-name: header;
 }
 
 /* ===== Breadcrumb ===== */
@@ -167,6 +248,7 @@ main {
     margin-top: var(--header-height);
     padding: 2rem;
     min-height: calc(100vh - var(--header-height));
+    view-transition-name: main-content;
 }
 
 /* ===== Index Page ===== */


### PR DESCRIPTION
- Changed about page source from about.txt to any .md file in root content path
- Link title now derived from filename (dashes converted to spaces)
- Page title extracted from first # heading in markdown
- Body content converted from markdown to HTML using pulldown-cmark crate
- Updated AboutPage struct to include link_title field across scan, process, and generate stages
- Replaced about.txt files with about.md equivalents

https://claude.ai/code/session_012v666896LdycejkEbU3q7u