### PR TITLE
Add release infrastructure

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,0 +1,46 @@
+name: 'Rust Setup'
+description: 'Install Rust toolchain, system dependencies, and cache everything'
+
+inputs:
+  rust-components:
+    description: 'Extra rustup components (e.g. clippy, rustfmt)'
+    required: false
+    default: ''
+  targets:
+    description: 'Extra Rust targets to install'
+    required: false
+    default: ''
+  install-imagemagick:
+    description: 'Install ImageMagick and image format dependencies'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install system dependencies
+      if: inputs.install-imagemagick == 'true'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y imagemagick webp libavif-bin
+        convert -version
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.rust-components }}
+        targets: ${{ inputs.targets }}
+
+    - name: Cache Cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ inputs.targets || 'native' }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.targets || 'native' }}-cargo-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,44 +15,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Run tests first - must pass before build/deploy
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Cache apt packages
-      - name: Cache apt packages
-        uses: actions/cache@v4
-        id: apt-cache
+      - name: Setup Rust with ImageMagick
+        uses: ./.github/actions/rust-setup
         with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-imagemagick-v1
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y imagemagick webp libavif-bin
-          convert -version
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          install-imagemagick: 'true'
 
       - name: Run tests
         run: cargo test --all-features
@@ -76,16 +48,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # Cache apt packages for image processing
-      - name: Cache apt packages
-        uses: actions/cache@v4
-        id: apt-cache
-        with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-imagemagick-v1
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,200 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Release version: $VERSION"
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract section between ## [VERSION] and next ## [
+          awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "Release v$VERSION" > release-notes.md
+          fi
+          echo "=== Release Notes ==="
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body_path: release-notes.md
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-binaries:
+    needs: create-release
+    # Run even if create-release was skipped (release already exists)
+    if: always() && !failure() && !cancelled()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: simple-gal-x86_64-linux-gnu
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: simple-gal-aarch64-linux-gnu
+            cross: true
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: simple-gal-aarch64-apple-darwin
+            cross: false
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: simple-gal-x86_64-windows
+            cross: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if asset already exists
+        id: check_asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          TAG="v$VERSION"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            ASSET="${{ matrix.artifact }}.zip"
+          else
+            ASSET="${{ matrix.artifact }}.tar.gz"
+          fi
+          if gh release view "$TAG" --json assets --jq ".assets[].name" 2>/dev/null | grep -q "^${ASSET}$"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Asset $ASSET already exists, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Rust
+        if: steps.check_asset.outputs.exists != 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo
+        if: steps.check_asset.outputs.exists != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Install cross
+        if: matrix.cross && steps.check_asset.outputs.exists != 'true'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build binary
+        if: steps.check_asset.outputs.exists != 'true'
+        shell: bash
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package binary (Unix)
+        if: matrix.os != 'windows-latest' && steps.check_asset.outputs.exists != 'true'
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/simple-gal dist/${{ matrix.artifact }}
+          cd dist
+          tar -czvf ../${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
+
+      - name: Package binary (Windows)
+        if: matrix.os == 'windows-latest' && steps.check_asset.outputs.exists != 'true'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/simple-gal.exe dist/${{ matrix.artifact }}.exe
+          cd dist
+          7z a ../${{ matrix.artifact }}.zip ${{ matrix.artifact }}.exe
+
+      - name: Upload to GitHub Release
+        if: steps.check_asset.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="v${{ needs.create-release.outputs.version }}"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            gh release upload "$TAG" "${{ matrix.artifact }}.zip" --clobber
+          else
+            gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz" --clobber
+          fi
+
+  publish-crates:
+    needs: create-release
+    # Run even if create-release was skipped (release already exists)
+    if: always() && !failure() && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-native-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-native-cargo-
+
+      - name: Publish to crates.io
+        env:
+          VERSION: ${{ needs.create-release.outputs.version }}
+        run: |
+          cargo publish --token ${{ secrets.CRATES_IO_KEY }} 2>&1 || {
+            if cargo search simple-gal --limit 1 2>/dev/null | grep -q "simple-gal.*\"$VERSION\""; then
+              echo "simple-gal@$VERSION already published, skipping"
+            else
+              echo "Failed to publish simple-gal"
+              exit 1
+            fi
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,29 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y imagemagick webp libavif-bin
-          # Verify ImageMagick is working (Ubuntu uses 'convert' not 'magick')
-          convert -version
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      # Cache Cargo dependencies
-      - name: Cache Cargo
-        uses: actions/cache@v4
+      - name: Setup Rust with ImageMagick
+        uses: ./.github/actions/rust-setup
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          install-imagemagick: 'true'
 
       - name: Run tests
         run: cargo test --all-features
@@ -56,31 +37,16 @@ jobs:
           path: target/release/simple-gal
           retention-days: 7
 
-  # Lint job runs in parallel with tests
-  # Uses the same script as the local pre-commit hook
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust with lint tools
+        uses: ./.github/actions/rust-setup
         with:
-          components: clippy, rustfmt
-
-      - name: Cache Cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-lint-
+          rust-components: clippy, rustfmt
 
       - name: Run checks (fmt, clippy, tests)
         run: ./scripts/pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-01-01
+
+### Added
+- Three-stage build pipeline: scan, process, generate
+- Responsive image processing with multiple output sizes
+- Thumbnail generation with configurable dimensions
+- AVIF and WebP format support
+- Hierarchical configuration system via `config.toml`
+- `gen-config` command for stock config generation
+- Album descriptions from `description.txt` with markdown support
+- Image metadata extraction from EXIF and sidecar files
+- `NNN-name` convention for ordering albums and images
+- Configurable thread pool for parallel image processing
+- Clean directory-based URLs for albums and images
+- GitHub Pages deployment workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-02-07
+
+### Added
+- Release infrastructure: CI workflows, cargo-release, --version flag
+- Shared composite action for Rust setup across workflows
+- Release workflow with cross-platform binary builds and crates.io publishing
+- `--version` flag shows version on release builds, `dev@hash` in development
+
 ## [0.1.0] - 2025-01-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "simple-gal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "maud",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "simple-gal"
 version = "0.1.0"
 edition = "2024"
+description = "A minimal static site generator for fine art photography portfolios"
+license = "MIT"
+repository = "https://github.com/arthur-debert/simple-gal"
+keywords = ["photography", "gallery", "static-site", "portfolio"]
+categories = ["command-line-utilities"]
+build = "build.rs"
+exclude = ["content/", "fixtures/", "tests/", "scripts/", "*.config.*", "package.json", "package-lock.json", "CNAME", "DEPENDENCIES.md", "local-build-and-serve.sh"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-gal"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A minimal static site generator for fine art photography portfolios"
 license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Arthur Debert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README-new.md
+++ b/README-new.md
@@ -1,0 +1,126 @@
+# Simple Gal: In It For The Long Run
+
+**Simple Gal** is a generator for web image galleries, built on a single core principle: **software should last**.
+
+<p align="center">
+  <img src="static/preview.png" alt="Simple Gal Preview" width="600">
+</p>
+
+## The Manifesto
+
+There are a million web image generators and platforms. We have all been burned by them.
+
+*   **Platforms disappear.** They get acquired, shut down, or pivot to video/AI/bloatware you don't need.
+*   **Complex tools break.** Self-hosted solutions often require databases, specific PHP versions, or Docker containers that become security liabilities or maintenance nightmares.
+*   **Data gets locked in.** Custom formats, databases, and "cloud" storage make it hard to leave.
+
+**Simple Gal is designed to work 30 years from now.**
+
+If you save the binary today, in 2056 it will still generate your site, provided:
+1.  **x86/ARM processors** still exist (or can be emulated).
+2.  **Browsers** still support HTML and CSS.
+3.  **ImageMagick** (or a compatible binary) exists.
+
+That's it. No databases. No migrations. No "cloud".
+
+## Core Philosophy
+
+### 1. The Filesystem is the Source of Truth
+Your data is just folders and files.
+*   **Albums** are directories.
+*   **Ordering** is done via filenames (`001-My-Image.jpg`).
+*   **Metadata** lives in sidecar text files or standard IPTC headers.
+*   **Moving data** in and out is as simple as copying files.
+
+### 2. Photography First
+Designed for photographers, not bloggers.
+*   **Precise Control**: You control the aspect ratios, sharpening, and compression quality.
+*   **Adaptive Images**: Generates multiple sizes to ensure your photos look great on 4K monitors and phones alike.
+*   **Distraction Free**: Minimal, clean UI that gets out of the way.
+
+### 3. Extreme Simplicity
+*   **Input**: A folder of images.
+*   **Output**: Static HTML/CSS files.
+*   **Deployment**: Copy the `dist` folder to *any* web server (Nginx, Apache, GitHub Pages, Netlify, an S3 bucket).
+
+## Getting Started
+
+### Option A: GitHub Integration (Recommended)
+1.  **Fork** this repository.
+2.  **Clone** your fork.
+3.  **Replace** the contents of `content/` with your own images.
+4.  **Push** your changes.
+    *   The included GitHub Actions will automatically build your site and publish it to GitHub Pages.
+
+### Option B: Run Locally
+1.  **Download** the latest binary for your OS from [Releases](#).
+2.  **Install Dependencies**: You need `ImageMagick` (see [DEPENDENCIES.md](DEPENDENCIES.md)).
+3.  **Run**:
+    ```bash
+    # Generate site from 'content' folder to 'dist' folder
+    simple-gal build
+    ```
+4.  **Preview**:
+    ```bash
+    # Serve the 'dist' folder
+    python3 -m http.server --directory dist
+    ```
+
+## How It Works
+
+### Directory Structure
+
+The structure of your `content` directory defines your site.
+
+```
+content/
+├── config.toml                  # Optional configuration
+├── 010-Travel/                  # Album (010 = sort order)
+│   ├── info.txt                 # Album description
+│   ├── 001-Paris.jpg            # Image
+│   ├── 002-London.jpg
+│   └── 003-Rome/                # Nested Album
+├── 020-Personal/
+│   └── ...
+└── 090-About.md                 # Standalone Page
+```
+
+### Naming Convention
+We use a simple `NNN-Name` convention to handle sorting and titling simultaneously.
+*   **`001-`**: Determines the sort order.
+*   **`Name`**: Becomes the title (dashes become spaces).
+    *   `010-Summer-Trip` -> Title: "Summer Trip", Position: 10.
+*   **Hidden Items**: Items without a number prefix are processed but hidden from the navigation menu (great for drafts).
+
+### Configuration
+A single `config.toml` file controls the generator. Defaults are sensible, but everything is tweakable.
+
+```toml
+[images]
+sizes = [800, 1400, 2080] # Generate these widths
+quality = 90              # High quality by default
+
+[theme]
+# Control the whitespace around your images
+frame_x = { size = "3vw", min = "1rem", max = "2.5rem" }
+```
+
+## Tech Stack (The "Forever" Stack)
+
+*   **Generator**: A single Rust binary. fast, safe, and portable.
+*   **Image Processing**: ImageMagick. The industry standard.
+*   **Frontend**: Pure HTML5 and CSS. No React, no Vue, no bundlers.
+    *   < 100 lines of vanilla JavaScript for navigation.
+    *   Dark/Light mode support via CSS variables.
+
+## Future Proofing
+
+In order for Simple Gal to stop working, one of the following must happen:
+1.  **Unix-like systems** cease to exist.
+2.  **Browsers** drop support for standard HTML/CSS.
+3.  **JPEG/WebP** formats are deprecated.
+
+We are betting against all three.
+
+---
+*Built for the long haul.*

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+fn main() {
+    // Re-run if git HEAD changes (new commits, checkouts, etc.)
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/");
+
+    let hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    let on_tag = std::process::Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .output()
+        .ok()
+        .is_some_and(|o| o.status.success());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rustc-env=ON_RELEASE_TAG={on_tag}");
+}

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,20 @@
+# cargo-release configuration
+# Usage: cargo release patch|minor|major
+
+# Update CHANGELOG.md: move Unreleased items under new version heading
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
+]
+
+# Create a git tag like v0.1.0
+tag-name = "v{{version}}"
+tag-message = "Release v{{version}}"
+
+# Commit the version bump and changelog update
+pre-release-commit-message = "chore: release v{{version}}"
+
+# Don't publish to crates.io from local — CI handles that
+publish = false
+
+# Push the tag (which triggers the CI release workflow)
+push = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,25 @@ mod types;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+fn version_string() -> &'static str {
+    let on_tag = env!("ON_RELEASE_TAG");
+    if on_tag == "true" {
+        env!("CARGO_PKG_VERSION")
+    } else {
+        let hash = env!("GIT_HASH");
+        if hash.is_empty() {
+            "dev@unknown"
+        } else {
+            // Leaked once at startup — trivial, called exactly once
+            Box::leak(format!("dev@{hash}").into_boxed_str())
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "simple-gal")]
 #[command(about = "Static site generator for photo portfolios")]
+#[command(version = version_string())]
 struct Cli {
     /// Content directory
     #[arg(long, default_value = "content", global = true)]


### PR DESCRIPTION
## Summary
- Shared composite action (`.github/actions/rust-setup/`) replacing duplicated Rust/ImageMagick/cache steps across test and deploy workflows
- Release workflow (`.github/workflows/release.yml`) triggered on `v*` tags: creates GitHub release with changelog notes, builds cross-platform binaries (Linux x86_64 + aarch64, macOS aarch64, Windows x86_64), publishes to crates.io
- Resilient design: each job skips if its artifact already exists (re-runnable on partial failures)
- `cargo-release` config (`release.toml`) for local version bumping, changelog updates, and tag creation
- `--version` CLI flag: prints version on release builds, `dev@<hash>` in development
- `CHANGELOG.md` with keep-a-changelog format, MIT `LICENSE`, crates.io metadata in `Cargo.toml`

## Verified
- v0.1.1 release fully tested: GitHub release created, 4 platform binaries attached, crates.io published

## Test plan
- [x] `cargo test --all-features` passes locally
- [x] CI test workflow passes on push
- [x] `cargo publish --dry-run` succeeds
- [x] `cargo release patch --dry-run` shows correct version bump and changelog update
- [x] Tag push triggers release workflow — all 6 jobs green
- [x] GitHub release has correct notes and 4 binary assets
- [x] crates.io shows `simple-gal = "0.1.1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)