### PR TITLE
Replace click-zone JS with pure HTML/CSS overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Replaced click-zone JavaScript with pure HTML/CSS `<a>` overlays, reducing nav.js from ~90 to ~30 lines
+- Fixed Escape key navigating to current page instead of album page
+
 ## [0.1.1] - 2026-02-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Print view shows "Album › Photo Title" credit line below the image
+
 ### Changed
 - Replaced click-zone JavaScript with pure HTML/CSS `<a>` overlays, reducing nav.js from ~90 to ~30 lines
 - Fixed Escape key navigating to current page instead of album page
+
+### Fixed
+- Print view: image disappeared when photo had a description (container query sizing collapsed without fixed viewport height)
+- Print view: page split into two pages due to fixed header margin and viewport-height layout
 
 ## [0.1.1] - 2026-02-07
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ simple-gal is a solution born out of this pain. It aims to be useful, simple, an
 
 - **Future-proof / Resilient**:
   - **The tool**: no external deps, pre-compiled binaries. As long as you can run a Unix program, it works.
-  - **The output**: tried-and-true HTML elements and established CSS, with only 80 lines of vanilla JavaScript. No dependencies, no front-end toolchain. Unless browsers break fundamental HTML support, you're good.
+  - **The output**: tried-and-true HTML elements and established CSS, with only ~30 lines of vanilla JavaScript (keyboard and swipe only — click navigation is pure HTML/CSS). No dependencies, no front-end toolchain. Unless browsers break fundamental HTML support, you're good.
   - **Formats**: TIFF, JPEG, AVIF, and WebP fallback.
   - **Hosting**: just drop the generated directory onto any file server. No configuration required.
 - **Photographic Control**:

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -673,6 +673,9 @@ fn render_image_page(
                         img #main-image src=(default_src) alt=(alt_text);
                     }
                 }
+                p.print-credit {
+                    (album.title) " › " (image_label)
+                }
                 @if let Some(text) = caption_text {
                     p.image-caption { (text) }
                 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -692,7 +692,8 @@ fn render_image_page(
                 }
             }
         }
-        div.nav-zones data-prev=(prev_url) data-next=(next_url) {}
+        a.nav-prev href=(prev_url) aria-label="Previous image" {}
+        a.nav-next href=(next_url) aria-label="Next image" {}
         script { (PreEscaped(JS)) }
     };
 
@@ -1049,7 +1050,7 @@ mod tests {
     }
 
     #[test]
-    fn render_image_page_navigation_zones() {
+    fn render_image_page_nav_links() {
         let album = create_test_album();
         let image = &album.images[0];
         let nav = vec![];
@@ -1066,9 +1067,10 @@ mod tests {
         )
         .into_string();
 
-        assert!(html.contains("nav-zones"));
-        assert!(html.contains("data-prev="));
-        assert!(html.contains("data-next="));
+        assert!(html.contains("nav-prev"));
+        assert!(html.contains("nav-next"));
+        assert!(html.contains(r#"aria-label="Previous image""#));
+        assert!(html.contains(r#"aria-label="Next image""#));
     }
 
     #[test]
@@ -1089,8 +1091,8 @@ mod tests {
             "Gallery",
         )
         .into_string();
-        assert!(html1.contains(r#"data-prev="../""#));
-        assert!(html1.contains(r#"data-next="../2/""#));
+        assert!(html1.contains(r#"class="nav-prev" href="../""#));
+        assert!(html1.contains(r#"class="nav-next" href="../2/""#));
 
         // Second image - has prev, no next (image[1] has no title)
         let html2 = render_image_page(
@@ -1105,8 +1107,8 @@ mod tests {
             "Gallery",
         )
         .into_string();
-        assert!(html2.contains(r#"data-prev="../1-Dawn/""#));
-        assert!(html2.contains(r#"data-next="../""#));
+        assert!(html2.contains(r#"class="nav-prev" href="../1-Dawn/""#));
+        assert!(html2.contains(r#"class="nav-next" href="../""#));
     }
 
     #[test]
@@ -1758,8 +1760,8 @@ mod tests {
             render_image_page(&album, image, None, None, &[], &[], "", "", "Gallery").into_string();
 
         // Both prev and next should go back to album
-        assert!(html.contains(r#"data-prev="../""#));
-        assert!(html.contains(r#"data-next="../""#));
+        assert!(html.contains(r#"class="nav-prev" href="../""#));
+        assert!(html.contains(r#"class="nav-next" href="../""#));
     }
 
     #[test]

--- a/static/nav.js
+++ b/static/nav.js
@@ -1,89 +1,34 @@
-// Simple Gal - Image Navigation
+// Simple Gal - Keyboard & Swipe Navigation
 (function() {
-    const zones = document.querySelector('.nav-zones');
-    if (!zones) return;
-
-    const prevUrl = zones.dataset.prev;
-    const nextUrl = zones.dataset.next;
-
-    // Apply navigation direction class for view transitions
-    const navDirection = sessionStorage.getItem('nav-direction');
-    if (navDirection) {
-        document.documentElement.classList.add('nav-' + navDirection);
-        sessionStorage.removeItem('nav-direction');
-    }
-
-    // Click navigation
-    document.addEventListener('click', function(e) {
-        // Ignore clicks on nav, links, etc.
-        if (e.target.closest('nav, a, button')) return;
-
-        const x = e.clientX / window.innerWidth;
-        if (x < 0.3) {
-            navigate(prevUrl, 'back');
-        } else if (x > 0.7) {
-            navigate(nextUrl, 'forward');
-        }
-    });
+    var prev = document.querySelector('.nav-prev');
+    var next = document.querySelector('.nav-next');
+    if (!prev && !next) return;
+    var prevUrl = prev && prev.getAttribute('href');
+    var nextUrl = next && next.getAttribute('href');
 
     // Keyboard navigation
     document.addEventListener('keydown', function(e) {
         if (e.key === 'ArrowLeft' || e.key === 'h') {
-            navigate(prevUrl, 'back');
+            if (prevUrl) location.href = prevUrl;
         } else if (e.key === 'ArrowRight' || e.key === 'l') {
-            navigate(nextUrl, 'forward');
+            if (nextUrl) location.href = nextUrl;
         } else if (e.key === 'Escape') {
-            navigate('index.html', 'back');
+            location.href = '../';
         }
     });
 
     // Touch/swipe navigation
-    let touchStartX = 0;
-    let touchStartY = 0;
-
+    var sx = 0, sy = 0;
     document.addEventListener('touchstart', function(e) {
-        touchStartX = e.touches[0].clientX;
-        touchStartY = e.touches[0].clientY;
+        sx = e.touches[0].clientX;
+        sy = e.touches[0].clientY;
     }, { passive: true });
-
     document.addEventListener('touchend', function(e) {
         if (e.target.closest('nav, a, button')) return;
-
-        const touchEndX = e.changedTouches[0].clientX;
-        const touchEndY = e.changedTouches[0].clientY;
-        const deltaX = touchEndX - touchStartX;
-        const deltaY = touchEndY - touchStartY;
-
-        // Only trigger if horizontal swipe is dominant
-        if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 50) {
-            if (deltaX > 0) {
-                navigate(prevUrl, 'back');
-            } else {
-                navigate(nextUrl, 'forward');
-            }
+        var dx = e.changedTouches[0].clientX - sx;
+        var dy = e.changedTouches[0].clientY - sy;
+        if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+            location.href = dx > 0 ? prevUrl : nextUrl;
         }
     }, { passive: true });
-
-    // Preload adjacent images
-    function preload(url) {
-        if (url && url !== 'index.html') {
-            const link = document.createElement('link');
-            link.rel = 'prefetch';
-            link.href = url;
-            document.head.appendChild(link);
-        }
-    }
-
-    preload(prevUrl);
-    preload(nextUrl);
-
-    function navigate(url, direction) {
-        if (url) {
-            // Store direction for the next page to pick up
-            if (direction) {
-                sessionStorage.setItem('nav-direction', direction);
-            }
-            window.location.href = url;
-        }
-    }
 })();

--- a/static/style.css
+++ b/static/style.css
@@ -393,16 +393,17 @@ body.image-view main {
     height: 100%;
 }
 
-/* Navigation zones (invisible) */
-.nav-zones {
+/* Click navigation zones (invisible prev/next links) */
+.nav-prev,
+.nav-next {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: var(--header-height);
     bottom: 0;
+    width: 30%;
     z-index: 10;
-    pointer-events: none;
 }
+.nav-prev { left: 0; }
+.nav-next { right: 0; }
 
 /* ===== Image Navigation Dots ===== */
 .image-nav {
@@ -512,7 +513,8 @@ body.has-description .image-page {
 /* ===== Print ===== */
 @media print {
     .site-nav,
-    .nav-zones,
+    .nav-prev,
+    .nav-next,
     .image-nav,
     .breadcrumb {
         display: none;

--- a/static/style.css
+++ b/static/style.css
@@ -505,6 +505,11 @@ body.has-description .image-page {
     }
 }
 
+/* ===== Print Credit (hidden on screen, visible in print) ===== */
+.print-credit {
+    display: none;
+}
+
 /* ===== Loading State ===== */
 .image-frame img {
     background: var(--color-border);
@@ -532,5 +537,32 @@ body.has-description .image-page {
     body.image-view main {
         height: auto;
         padding: 0;
+    }
+
+    /* Container queries need a fixed-size ancestor; disable for print */
+    .image-page {
+        container-type: normal;
+    }
+
+    .image-frame {
+        width: 100%;
+        height: auto;
+    }
+
+    body.has-caption .image-frame {
+        width: 100%;
+        height: auto;
+    }
+
+    .image-description {
+        overflow: visible;
+    }
+
+    /* Print credit line below image */
+    .print-credit {
+        display: block;
+        font-size: var(--font-size-small);
+        color: var(--color-text);
+        padding-top: 0.75rem;
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -561,6 +561,7 @@ body.has-description .image-page {
     /* Print credit line below image */
     .print-credit {
         display: block;
+        width: 100%;
         font-size: var(--font-size-small);
         color: var(--color-text);
         padding-top: 0.75rem;

--- a/static/style.css
+++ b/static/style.css
@@ -512,15 +512,25 @@ body.has-description .image-page {
 
 /* ===== Print ===== */
 @media print {
+    .site-header,
     .site-nav,
     .nav-prev,
     .nav-next,
-    .image-nav,
-    .breadcrumb {
+    .image-nav {
         display: none;
     }
 
     main {
+        margin-top: 0;
         margin-left: 0;
+    }
+
+    body.image-view {
+        overflow: visible;
+    }
+
+    body.image-view main {
+        height: auto;
+        padding: 0;
     }
 }


### PR DESCRIPTION
## Summary
- Replace click navigation zones (JS event listener checking x-coordinate) with two positioned `<a>` elements (`.nav-prev` / `.nav-next`) — pure HTML/CSS
- Remove unused sessionStorage direction tracking (no CSS consumed it)
- Remove redundant JS prefetch (already handled by `<link rel="preload">` in `<head>`)
- Fix Escape key navigating to current page instead of album page
- **nav.js: 90 → 34 lines** (keeps keyboard + swipe only)

## Test plan
- [x] All 259 unit tests pass (3 nav tests updated for new HTML structure)
- [x] Built test site — verified `<a class="nav-prev">` and `<a class="nav-next">` appear with correct `href` and `aria-label`
- [x] Verified no `nav-zones` or `data-prev`/`data-next` in generated HTML
- [x] Updated README.md JS line count and CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)