### PR TITLE
Add static assets directory and local font support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Static assets directory: `assets/` contents are copied verbatim to the output root (favicon, fonts, robots.txt, etc.)
+- Local font support: `source` field in `[font]` config generates `@font-face` CSS instead of loading from Google Fonts
+- Favicon auto-detection: `favicon.ico`, `.svg`, or `.png` in assets directory automatically gets a `<link rel="icon">` tag
 - Print view shows "Album › Photo Title" credit line below the image
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ cargo test --test browser_layout -- --ignored       # browser layout tests (need
 
 **Principles:** unit-test first; all pipeline logic is pure functions on data — no integration tests needed for correctness. Browser tests for CSS layout only. See `docs/dev/testing.md` for the full guide.
 
-**Shared fixtures:** `fixtures/content/` exercises the full feature set (config chain, sidecars, markdown priority, nested albums, pages, link pages, hidden dirs). Tests copy it to a temp dir via `setup_fixtures()`.
+**Shared fixtures:** `fixtures/content/` exercises the full feature set (config chain, sidecars, markdown priority, nested albums, pages, link pages, hidden dirs, assets directory). Tests copy it to a temp dir via `setup_fixtures()`.
 
 **Test helpers:** `src/test_helpers.rs` — lookup helpers (`find_album`, `find_image`, `find_page`), bulk extractors (`album_titles`, `image_titles`), nav assertions (`assert_nav_shape`). Use these instead of writing ad-hoc fixture setup.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Any `NNN-<name>.md` file in the content root is added as a page in the navigatio
 ```text
 content/
 ├── config.toml                    # Site configuration (optional)
+├── assets/                        # Static assets → copied to output root
+│   ├── favicon.ico                # Auto-detected, injected into <head>
+│   └── fonts/                     # Custom fonts (referenced in config.toml)
 ├── 040-about.md                   # Page (numbered = shown in nav)
 ├── 050-github.md                  # Link page (URL-only .md file)
 ├── 010-Landscapes/                # Album (numbered = shown in nav)
@@ -87,6 +90,24 @@ Key points:
 - Items without a prefix are processed but hidden from navigation and thumbnail grids; they remain accessible by direct URL.
 - Metadata can come from the image's IPTC tags, sidecar files, or filenames.
 - Configuration cascades: root > group > gallery. Only overridden values need to be specified.
+
+## Static Assets
+
+The `assets/` directory (configurable via `assets_dir` in `config.toml`) is copied verbatim to the output root. Use it for favicons, custom fonts, or any other static files your site needs.
+
+Favicon files (`favicon.ico`, `favicon.svg`, `favicon.png`) are auto-detected and injected as `<link rel="icon">` in every page.
+
+To use a custom/downloaded font instead of Google Fonts:
+
+```toml
+[font]
+font = "My Custom Font"
+weight = "400"
+font_type = "sans"
+source = "fonts/MyFont.woff2"   # path relative to site root
+```
+
+Place the font file in `assets/fonts/` and it will be copied to `dist/fonts/` during build. When `source` is set, a `@font-face` declaration is generated and Google Fonts loading is skipped entirely.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A `config.toml` in the content root sets global preferences. Each gallery can ha
 
 Any `NNN-<name>.md` file in the content root is added as a page in the navigation (e.g. `001-About.md`).
 
-```
+```text
 content/
 ├── config.toml                    # Site configuration (optional)
 ├── 040-about.md                   # Page (numbered = shown in nav)

--- a/content/config.toml
+++ b/content/config.toml
@@ -84,7 +84,7 @@ link_hover = "#ffffff"
 # ---------------------------------------------------------------------------
 [font]
 # Google Fonts family name.
-font = "Noto Sants"
+font = "Noto Sans"
 
 # Font weight to load from Google Fonts.
 weight = "400"

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ Content structure:
 
   content/
   ├── config.toml                  # Site config (optional, cascades to children)
+  ├── assets/                      # Static assets (favicon, fonts) → copied to output root
   ├── 040-about.md                 # Page (numbered = shown in nav)
   ├── 050-github.md                # Link page (URL-only .md → external nav link)
   ├── 010-Landscapes/              # Album (numbered = shown in nav)
@@ -168,7 +169,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Generate => {
             let processed_dir = cli.temp_dir.join("processed");
             let processed_manifest_path = processed_dir.join("manifest.json");
-            generate::generate(&processed_manifest_path, &processed_dir, &cli.output)?;
+            generate::generate(
+                &processed_manifest_path,
+                &processed_dir,
+                &cli.output,
+                &cli.source,
+            )?;
         }
         Command::Build => {
             // Resolve content root: check config.toml in source dir for content_root override
@@ -192,7 +198,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::fs::write(&processed_manifest_path, &json)?;
 
             println!("==> Stage 3: Generating HTML");
-            generate::generate(&processed_manifest_path, &processed_dir, &cli.output)?;
+            generate::generate(
+                &processed_manifest_path,
+                &processed_dir,
+                &cli.output,
+                &source,
+            )?;
 
             println!("==> Build complete: {}", cli.output.display());
         }

--- a/static/style.css
+++ b/static/style.css
@@ -361,7 +361,7 @@ body.image-view main {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: var(--frame-width-y) var(--frame-width-x);
+    padding: var(--frame-width-y) var(--frame-width-x) 0;
     height: calc(100dvh - var(--header-height));
     position: relative;
 }


### PR DESCRIPTION
## Summary

- **Static assets directory**: Configurable `assets/` directory (default: `content/assets/`) whose contents are copied verbatim to the output root during generation. Keeps non-photo files (favicons, fonts, robots.txt) separate from photo content.
- **Local font support**: New `source` field in `[font]` config generates `@font-face` CSS instead of loading from Google Fonts. Font format auto-detected from file extension.
- **Favicon auto-detection**: `favicon.ico`, `.svg`, or `.png` in the assets directory automatically gets a `<link rel="icon">` tag in every page.

## Test plan

- [x] All 272 existing tests pass
- [x] New config tests: `parse_custom_assets_dir`, `parse_font_with_source`, `local_font_generates_font_face_css`, `local_font_has_no_stylesheet_url`, `font_format_detection`, `generate_font_css_includes_font_face_for_local`, `generate_font_css_no_font_face_for_google`, `merge_font_source_preserves_other_fields`, `merge_preserves_default_assets_dir`, `default_assets_dir`, `default_font_is_google`
- [x] New scan tests: `assets_dir_skipped_during_scan`, `custom_assets_dir_skipped_during_scan`
- [ ] Manual test: add `assets/favicon.ico` and `assets/fonts/test.woff2` to content, run build, verify files in dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)