### PR TITLE
Improve album detail page layout

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -549,7 +549,12 @@ fn render_album_page(
             header.album-header {
                 h1 { (album.title) }
                 @if let Some(desc) = &album.description {
+                    input.desc-toggle type="checkbox" id="desc-toggle";
                     div.album-description { (PreEscaped(desc)) }
+                    label.desc-expand for="desc-toggle" {
+                        span.expand-more { "Read more" }
+                        span.expand-less { "Show less" }
+                    }
                 }
             }
             div.thumbnail-grid {

--- a/static/style.css
+++ b/static/style.css
@@ -489,6 +489,27 @@ body.has-description .image-page {
     white-space: pre-line;
 }
 
+/* ===== Large Desktop: side-by-side description + thumbnails ===== */
+@media (min-width: 1200px) {
+    .album-page {
+        display: grid;
+        grid-template-columns: 2fr 5fr;
+        gap: 0 var(--thumbnail-gap);
+    }
+
+    .album-header {
+        position: sticky;
+        top: calc(var(--header-height) + 2rem);
+        align-self: start;
+        padding-left: var(--grid-padding);
+        padding-top: var(--grid-padding);
+    }
+
+    .album-description {
+        max-width: none;
+    }
+}
+
 /* ===== Mobile Styles ===== */
 @media (max-width: 768px) {
     .site-header {

--- a/static/style.css
+++ b/static/style.css
@@ -297,7 +297,8 @@ main {
 }
 
 .album-header {
-    margin-bottom: 2rem;
+    padding-left: var(--grid-padding);
+    margin-bottom: 0;
 }
 
 .album-header h1 {
@@ -307,9 +308,15 @@ main {
 }
 
 .album-description {
-    color: var(--color-text);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-small);
+    line-height: 1.6;
     max-width: 600px;
 }
+
+/* Hidden checkbox for description expand/collapse toggle */
+.desc-toggle { display: none; }
+.desc-expand { display: none; }
 
 .thumbnail-grid {
     display: grid;
@@ -503,6 +510,44 @@ body.has-description .image-page {
     .thumbnail-grid {
         grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     }
+
+    /* Truncate long album descriptions with expand toggle */
+    .album-description {
+        max-height: 6.4em;
+        overflow: hidden;
+        position: relative;
+    }
+
+    .album-description::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 2em;
+        background: linear-gradient(transparent, var(--color-bg));
+    }
+
+    .desc-expand {
+        display: inline-block;
+        color: var(--color-text-muted);
+        font-size: var(--font-size-small);
+        cursor: pointer;
+        margin-top: 0.25rem;
+    }
+
+    .desc-expand .expand-less { display: none; }
+
+    .desc-toggle:checked ~ .album-description {
+        max-height: none;
+    }
+
+    .desc-toggle:checked ~ .album-description::after {
+        display: none;
+    }
+
+    .desc-toggle:checked ~ .desc-expand .expand-more { display: none; }
+    .desc-toggle:checked ~ .desc-expand .expand-less { display: inline; }
 }
 
 /* ===== Print Credit (hidden on screen, visible in print) ===== */


### PR DESCRIPTION
## Summary
- Reduce album description font size and color to match image descriptions (14px, muted)
- Align title/description to thumbnail grid left edge via `padding-left: var(--grid-padding)`
- On mobile (≤768px): truncate long descriptions with gradient fade and CSS-only "Read more" / "Show less" toggle
- On large screens (≥1200px): two-column layout with sticky description on the left and thumbnail grid on the right

## Test plan
- [ ] Build site and open album page with long description
- [ ] Verify description text is smaller and muted
- [ ] Verify title aligns with thumbnail grid
- [ ] Test at ≥1200px: description and thumbnails side-by-side, description sticky on scroll
- [ ] Test at 769–1199px: stacked layout (description above thumbnails)
- [ ] Test at ≤768px: description truncated with "Read more" toggle
- [ ] Test album without description: no toggle markup, layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)