### PR TITLE
fix: Align photo page layout with spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Photo page layout: added bottom mat, description scrolls with photo instead of independently, teaser peeks above nav dots
+- Renamed `frame_width` config to `mat` (breaking: update `config.toml` sections from `[theme.frame_x]`/`[theme.frame_y]` to `[theme.mat_x]`/`[theme.mat_y]`)
+
 ## [0.2.0] - 2026-02-14
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -479,7 +479,7 @@ body.has-description main::-webkit-scrollbar {
 }
 
 body.has-description .image-page {
-    --desc-peek: 3.5rem;
+    --desc-peek: 4.5rem;
     flex: 0 0 calc(100% - var(--mat-y) - var(--desc-peek));
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -383,6 +383,7 @@ body.image-view main {
     align-items: center;
     justify-content: center;
     container-type: size;
+    margin-bottom: var(--mat-y); /* bottom mat */
 }
 
 .image-frame {
@@ -465,19 +466,30 @@ body.has-caption .image-frame {
 }
 
 /* ===== Image Description ===== */
-/* Long text scrolls independently between image and bottom dots. */
+/* Long text (>160 chars). Below the mat, scrolls with the photo.
+   The photo shrinks by --desc-peek so a 1-2 line teaser peeks above
+   the nav dots. Scrolling reveals the full description. */
 body.has-description main {
-    padding-bottom: 0;
+    overflow-y: auto;
+    scrollbar-width: none;
+}
+
+body.has-description main::-webkit-scrollbar {
+    display: none;
 }
 
 body.has-description .image-page {
-    flex: 3;
+    --desc-peek: 3.5rem;
+    flex: 0 0 calc(100% - var(--mat-y) - var(--desc-peek));
+}
+
+body.has-description .image-nav {
+    position: sticky;
+    bottom: 0;
+    background: var(--color-bg);
 }
 
 .image-description {
-    flex: 1 1 0;
-    min-height: 0;
-    overflow-y: auto;
     width: 100%;
     max-width: 65ch;
     padding: 1rem 1rem 2rem;
@@ -522,7 +534,7 @@ body.has-description .image-page {
     }
 
     body.image-view main {
-        padding: var(--mat-y) var(--mat-x);
+        padding: var(--mat-y) var(--mat-x) 0;
     }
 
     .album-grid {


### PR DESCRIPTION
## Summary
- Adds bottom mat (`margin-bottom: var(--mat-y)`) to `.image-page` for all three layout variants
- Rewrites description layout so `main` scrolls as a unit (photo + description together), with `.image-nav` sticky at the bottom and `--desc-peek` shrinking the photo to guarantee teaser visibility
- Fixes mobile padding override that was adding unwanted bottom padding

## Test plan
- [x] All 273 unit tests pass
- [x] Browser layout tests updated: 3 old description tests replaced with 5 new ones covering teaser visibility, main scrollability, scroll-as-a-unit behavior, description below mat, and nav dots visibility
- [ ] Run browser tests with Chrome: `cargo test --test browser_layout -- --ignored`
- [ ] Visual check of photo-only, caption, and description variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)