### PR TITLE
Remove WebP output — AVIF-only images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed WebP output format — all responsive images and thumbnails are now AVIF-only (AVIF has had full browser support since September 2022)
+- Simplified image pages from `<picture>` with AVIF/WebP srcsets to plain `<img>` with AVIF srcset
+- Removed `webp` crate dependency, eliminating the last C build dependency (libwebp-sys)
+- Removed ImageMagick backend — pure Rust image processing only, zero system dependencies
+- Removed `[backend]` config section (was selecting between ImageMagick and Rust backends)
+
 ### Fixed
 - Photo page layout: added bottom mat, description scrolls with photo instead of independently, teaser peeks above nav dots
 - Renamed `frame_width` config to `mat` (breaking: update `config.toml` sections from `[theme.frame_x]`/`[theme.frame_y]` to `[theme.mat_x]`/`[theme.mat_y]`)
@@ -48,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Three-stage build pipeline: scan, process, generate
 - Responsive image processing with multiple output sizes
 - Thumbnail generation with configurable dimensions
-- AVIF and WebP format support
+- AVIF format support
 - Hierarchical configuration system via `config.toml`
 - `gen-config` command for stock config generation
 - Album descriptions from `description.txt` with markdown support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,12 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,16 +913,6 @@ checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libwebp-sys"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
-dependencies = [
- "cc",
- "glob",
 ]
 
 [[package]]
@@ -1557,7 +1541,6 @@ dependencies = [
  "thiserror",
  "toml",
  "walkdir",
- "webp",
 ]
 
 [[package]]
@@ -1913,16 +1896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "webp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
-dependencies = [
- "image",
- "libwebp-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ image = { version = "0.25", default-features = false, features = [
     "jpeg", "png", "tiff", "webp",
     "avif",
 ] }
-webp = "0.3"
 maud = "0.26"
 pulldown-cmark = "0.13"
 rayon = "1"

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # System Dependencies
 
-Simple Gal has **no system-level dependencies**. All image processing (JPEG/PNG/WebP/AVIF decode, resize, encode, IPTC metadata extraction) is handled by pure Rust libraries compiled into the binary.
+Simple Gal has **no system-level dependencies**. All image processing (JPEG/PNG/TIFF/WebP decode, AVIF encode, resize, IPTC metadata extraction) is handled by pure Rust libraries compiled into the binary.
 
 ## Build Requirements
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ simple-gal is a solution born out of this pain. It aims to be useful, simple, an
 - **Future-proof / Resilient**:
   - **The tool**: no external deps, pre-compiled binaries. As long as you can run a Unix program, it works.
   - **The output**: tried-and-true HTML elements and established CSS, with only ~30 lines of vanilla JavaScript (keyboard and swipe only — click navigation is pure HTML/CSS). No dependencies, no front-end toolchain. Unless browsers break fundamental HTML support, you're good.
-  - **Formats**: TIFF, JPEG, AVIF, and WebP fallback.
+  - **Formats**: TIFF, JPEG, and AVIF output.
   - **Hosting**: just drop the generated directory onto any file server. No configuration required.
 - **Photographic Control**:
   - **Image quality**: fine-tune compression and sharpening, per size.

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@
 //!
 //! [images]
 //! sizes = [800, 1400, 2080] # Responsive sizes to generate
-//! quality = 90              # AVIF/WebP quality (0-100)
+//! quality = 90              # AVIF quality (0-100)
 //!
 //! [theme]
 //! thumbnail_gap = "1rem"    # Gap between thumbnails in grids
@@ -452,7 +452,7 @@ impl Default for ThumbnailsConfig {
 pub struct ImagesConfig {
     /// Pixel widths (longer edge) to generate for responsive `<picture>` elements.
     pub sizes: Vec<u32>,
-    /// AVIF/WebP encoding quality (0 = worst, 100 = best).
+    /// AVIF encoding quality (0 = worst, 100 = best).
     pub quality: u32,
 }
 
@@ -798,7 +798,7 @@ size = 400
 # Pixel widths (longer edge) to generate for responsive <picture> elements.
 sizes = [800, 1400, 2080]
 
-# AVIF/WebP encoding quality (0 = worst, 100 = best).
+# AVIF encoding quality (0 = worst, 100 = best).
 quality = 90
 
 # ---------------------------------------------------------------------------

--- a/src/imaging/mod.rs
+++ b/src/imaging/mod.rs
@@ -4,7 +4,6 @@
 //! |---|---|
 //! | **Identify** | `image::image_dimensions` |
 //! | **IPTC metadata** | custom parser (JPEG APP13 + TIFF IFD) |
-//! | **Resize → WebP** | Lanczos3 + `webp` crate (vendored libwebp) |
 //! | **Resize → AVIF** | Lanczos3 + rav1e encoder |
 //! | **Thumbnail** | `resize_to_fill` + `unsharpen` |
 //!


### PR DESCRIPTION
## Summary

- Removed WebP output format entirely — all responsive images and thumbnails are now AVIF-only
- Simplified `<picture>` element with AVIF/WebP srcsets to plain `<img>` with AVIF srcset
- Removed `webp` crate dependency, eliminating the last C build dependency (libwebp-sys)
- WebP **input** decoding preserved (photographers can still use WebP source files)

AVIF has had full browser support since September 2022 (Safari 16 was the last holdout).

## Changes

- **Cargo.toml**: Removed `webp` crate; kept `"webp"` feature in `image` crate for input decoding
- **rust_backend.rs**: Removed `save_webp` function and WebP output format
- **operations.rs**: Removed `webp_path` from `GeneratedVariant`, changed thumbnails from `.webp` to `.avif`
- **process.rs**: Removed `webp` field from `GeneratedVariant`, updated operation count expectations
- **generate.rs**: Simplified from `<picture>` with dual srcsets to `<img>` with AVIF srcset
- **config.rs**: Updated quality comments from "AVIF/WebP" to "AVIF"
- **README.md, CHANGELOG.md, DEPENDENCIES.md**: Updated documentation

## Test plan

- [x] All 266 unit tests pass
- [x] Clippy clean
- [x] Pre-commit hooks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)