### PR TITLE
Add custom CSS/JS injection via convention files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Custom CSS/JS injection via convention files in `assets/` — zero configuration needed:
+  - `custom.css`: linked after main styles for CSS overrides
+  - `head.html`: raw HTML injected at end of `<head>` (analytics, meta tags, etc.)
+  - `body-end.html`: raw HTML injected before `</body>` (tracking scripts, widgets)
+
 ## [0.2.1] - 2026-02-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ source = "fonts/MyFont.woff2"   # path relative to site root
 
 Place the font file in `assets/fonts/` and it will be copied to `dist/fonts/` during build. When `source` is set, a `@font-face` declaration is generated and Google Fonts loading is skipped entirely.
 
+## Custom CSS & JS
+
+Drop any of these convention files into your `assets/` directory to inject custom content — no configuration needed:
+
+| File | Injection point | Use case |
+|------|----------------|----------|
+| `custom.css` | `<link>` after main styles | CSS overrides, layout tweaks |
+| `head.html` | End of `<head>` | Analytics (GA, Plausible), Open Graph meta tags |
+| `body-end.html` | Before `</body>` | Tracking scripts, chat widgets, cookie banners |
+
+For example, to add Plausible analytics, create `assets/head.html`:
+
+```html
+<script defer data-domain="photos.example.com" src="https://plausible.io/js/script.js"></script>
+```
+
+To override gallery styles, create `assets/custom.css`:
+
+```css
+.album-grid { gap: 0.5rem; }
+```
+
+The files are injected as-is — broken syntax won't break the build, it will just produce broken output.
+
 ## PWA / Installable Gallery
 
 Every generated site is a Progressive Web App out of the box — no configuration needed. Visitors can "Add to Home Screen" on any device to get an app-like experience with:

--- a/src/config.rs
+++ b/src/config.rs
@@ -876,6 +876,16 @@ font_type = "sans"
 # Maximum parallel image-processing workers.
 # Omit or comment out to auto-detect (= number of CPU cores).
 # max_processes = 4
+
+# ---------------------------------------------------------------------------
+# Custom CSS & HTML Snippets
+# ---------------------------------------------------------------------------
+# Drop any of these files into your assets/ directory to inject custom content.
+# No configuration needed — the files are detected automatically.
+#
+#   assets/custom.css    → <link rel="stylesheet"> after main styles (CSS overrides)
+#   assets/head.html     → raw HTML at the end of <head> (analytics, meta tags)
+#   assets/body-end.html → raw HTML before </body> (tracking scripts, widgets)
 "##
 }
 


### PR DESCRIPTION
## Summary
- Users can now inject custom content by dropping convention files into `assets/`:
  - `custom.css` → `<link rel="stylesheet">` after main styles (CSS overrides)
  - `head.html` → raw HTML at end of `<head>` (analytics, Open Graph meta tags)
  - `body-end.html` → raw HTML before `</body>` (tracking scripts, widgets)
- Zero configuration needed — file presence is auto-detected after assets are copied
- Broken user HTML/CSS won't break the build (injected as raw strings, same as markdown content)

## Test plan
- [x] 12 new unit tests covering all injection points, ordering, detection logic, and all page types
- [x] All 278 tests pass (266 existing + 12 new)
- [x] Clippy and rustfmt clean
- [ ] Manual test: drop a `custom.css` into fixtures assets and verify `<link>` appears in generated HTML
- [ ] Manual test: drop a `head.html` with an analytics snippet and verify injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)