### PR TITLE
Add structured CLI output formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Structured CLI output: tree-based formatting for scan, process, and generate stages
+  - Albums shown with positional indices, photo counts, source directories, and truncated descriptions
+  - Process output shows generated image sizes per photo
+  - Generate output shows output file paths per album and image page
+  - Navigation tree walked for consistent hierarchy display
+- `source_dir` field on `NavItem` tracking original directory basename
+- `support_files` field on `Album` tracking config and description files
+
+### Changed
+- Replaced ad-hoc `println!` output across pipeline stages with centralized `output` module
+- Build command stage headers now include source/output paths
+
 ## [0.3.1] - 2026-02-16
 
 ## [0.3.0] - 2026-02-16

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,522 @@
+//! CLI output formatting for all pipeline stages.
+//!
+//! Provides structured, tree-based output showing the gallery hierarchy
+//! with semantic positional indices. Each stage has a dedicated formatter.
+
+use crate::types::NavItem;
+use std::path::Path;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Strip HTML tags from a string (simple angle-bracket stripping).
+fn strip_html_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => result.push(c),
+            _ => {}
+        }
+    }
+    result
+}
+
+/// Truncate text to `max` characters, appending `...` if truncated.
+fn truncate_desc(text: &str, max: usize) -> String {
+    if text.len() <= max {
+        text.to_string()
+    } else {
+        format!("{}...", &text[..max])
+    }
+}
+
+/// Format a 1-based positional index as 3-digit zero-padded.
+fn format_index(pos: usize) -> String {
+    format!("{:0>3}", pos)
+}
+
+/// Return indentation string: 4 spaces per depth level.
+fn indent(depth: usize) -> String {
+    "    ".repeat(depth)
+}
+
+// ============================================================================
+// Tree walker
+// ============================================================================
+
+/// A flattened node from walking the NavItem tree.
+struct TreeNode {
+    depth: usize,
+    position: usize,
+    path: String,
+    is_container: bool,
+    source_dir: String,
+}
+
+/// Walk the navigation tree, assigning positional indices per sibling level.
+/// Returns a flat list of nodes with depth and position for formatting.
+fn walk_nav_tree(nav: &[NavItem]) -> Vec<TreeNode> {
+    let mut nodes = Vec::new();
+    walk_nav_tree_recursive(nav, 0, &mut nodes);
+    nodes
+}
+
+fn walk_nav_tree_recursive(items: &[NavItem], depth: usize, nodes: &mut Vec<TreeNode>) {
+    for (i, item) in items.iter().enumerate() {
+        let is_container = !item.children.is_empty();
+        nodes.push(TreeNode {
+            depth,
+            position: i + 1,
+            path: item.path.clone(),
+            is_container,
+            source_dir: item.source_dir.clone(),
+        });
+        if is_container {
+            walk_nav_tree_recursive(&item.children, depth + 1, nodes);
+        }
+    }
+}
+
+// ============================================================================
+// Stage 1: Scan output
+// ============================================================================
+
+/// Format scan stage output showing discovered gallery structure.
+pub fn format_scan_output(manifest: &crate::scan::Manifest, source_root: &Path) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    // Albums section
+    lines.push("Albums".to_string());
+
+    let tree_nodes = walk_nav_tree(&manifest.navigation);
+
+    // Track which album paths we've shown via nav tree
+    let mut shown_paths = std::collections::HashSet::new();
+
+    for node in &tree_nodes {
+        let prefix = format!("{}{}", indent(node.depth), format_index(node.position));
+
+        if node.is_container {
+            // Container directory (no images, just children)
+            lines.push(format!(
+                "{} {} [{}]",
+                prefix,
+                node.path.split('/').next_back().unwrap_or(&node.path),
+                node.source_dir
+            ));
+        } else {
+            // Leaf album — find matching album in manifest
+            if let Some(album) = manifest.albums.iter().find(|a| a.path == node.path) {
+                shown_paths.insert(&album.path);
+                let photo_count = album.images.len();
+                let mut line = format!(
+                    "{} {} ({} photos) [{}]",
+                    prefix, album.title, photo_count, node.source_dir
+                );
+                if let Some(ref desc) = album.description {
+                    let plain = strip_html_tags(desc);
+                    let truncated = truncate_desc(plain.trim(), 40);
+                    line.push_str(&format!(": {}", truncated));
+                }
+                lines.push(line);
+
+                // Support files
+                for sf in &album.support_files {
+                    lines.push(format!("{}    {}", indent(node.depth), sf));
+                }
+
+                // Images with sidecar info
+                for img in &album.images {
+                    let sidecar_path = source_root.join(&img.source_path).with_extension("txt");
+                    let sidecar_info = if sidecar_path.exists() {
+                        let sidecar_name = sidecar_path.file_name().unwrap().to_string_lossy();
+                        format!(" [{} {}]", img.filename, sidecar_name)
+                    } else {
+                        format!(" [{}]", img.filename)
+                    };
+                    lines.push(format!("{}   {}", indent(node.depth), sidecar_info));
+                }
+            }
+        }
+    }
+
+    // Un-navigated albums
+    for album in &manifest.albums {
+        if !shown_paths.contains(&album.path) {
+            let photo_count = album.images.len();
+            let dir_name = album.path.split('/').next_back().unwrap_or(&album.path);
+            let mut line = format!("    {} ({} photos)", dir_name, photo_count);
+            if let Some(ref desc) = album.description {
+                let plain = strip_html_tags(desc);
+                let truncated = truncate_desc(plain.trim(), 40);
+                line.push_str(&format!(": {}", truncated));
+            }
+            lines.push(line);
+        }
+    }
+
+    // Pages section
+    if !manifest.pages.is_empty() {
+        lines.push(String::new());
+        lines.push("Pages".to_string());
+        for (i, page) in manifest.pages.iter().enumerate() {
+            let idx = format_index(i + 1);
+            let link_marker = if page.is_link { " (link)" } else { "" };
+            let filename = format!("[{}.md]", page.slug);
+            lines.push(format!(
+                "    {} {}{} {}",
+                idx, page.title, link_marker, filename
+            ));
+        }
+    }
+
+    // Config section
+    lines.push(String::new());
+    lines.push("Config".to_string());
+    let config_path = source_root.join("config.toml");
+    if config_path.exists() {
+        lines.push("    config.toml".to_string());
+    }
+    let assets_path = source_root.join(&manifest.config.assets_dir);
+    if assets_path.is_dir() {
+        lines.push(format!("    {}/", manifest.config.assets_dir));
+    }
+
+    lines
+}
+
+/// Print scan output to stdout.
+pub fn print_scan_output(manifest: &crate::scan::Manifest, source_root: &Path) {
+    for line in format_scan_output(manifest, source_root) {
+        println!("{}", line);
+    }
+}
+
+// ============================================================================
+// Stage 2: Process output
+// ============================================================================
+
+/// Format process stage output showing generated image sizes.
+pub fn format_process_output(manifest: &crate::process::OutputManifest) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let tree_nodes = walk_nav_tree(&manifest.navigation);
+    let mut shown_paths = std::collections::HashSet::new();
+    let mut total_images = 0;
+
+    for node in &tree_nodes {
+        let prefix = format!("{}{}", indent(node.depth), format_index(node.position));
+
+        if node.is_container {
+            lines.push(format!(
+                "{} {}",
+                prefix,
+                node.path.split('/').next_back().unwrap_or(&node.path)
+            ));
+        } else if let Some(album) = manifest.albums.iter().find(|a| a.path == node.path) {
+            shown_paths.insert(&album.path);
+            lines.push(format!(
+                "{} {} ({} photos)",
+                prefix,
+                album.title,
+                album.images.len()
+            ));
+            total_images += album.images.len();
+
+            for img in &album.images {
+                let sizes: Vec<String> = img.generated.keys().cloned().collect();
+                let sizes_str = sizes.join(" ");
+                let title_part = img.title.as_deref().unwrap_or(&img.slug);
+                lines.push(format!(
+                    "{}    {} → {} + thumb",
+                    indent(node.depth),
+                    title_part,
+                    sizes_str
+                ));
+            }
+        }
+    }
+
+    // Un-navigated albums
+    for album in &manifest.albums {
+        if !shown_paths.contains(&album.path) {
+            lines.push(format!(
+                "    {} ({} photos)",
+                album.title,
+                album.images.len()
+            ));
+            total_images += album.images.len();
+
+            for img in &album.images {
+                let sizes: Vec<String> = img.generated.keys().cloned().collect();
+                let sizes_str = sizes.join(" ");
+                let title_part = img.title.as_deref().unwrap_or(&img.slug);
+                lines.push(format!("        {} → {} + thumb", title_part, sizes_str));
+            }
+        }
+    }
+
+    lines.push(format!(
+        "Processed {} albums, {} images",
+        manifest.albums.len(),
+        total_images
+    ));
+
+    lines
+}
+
+/// Print process output to stdout.
+pub fn print_process_output(manifest: &crate::process::OutputManifest) {
+    for line in format_process_output(manifest) {
+        println!("{}", line);
+    }
+}
+
+// ============================================================================
+// Stage 3: Generate output
+// ============================================================================
+
+/// Format generate stage output showing generated HTML files.
+pub fn format_generate_output(manifest: &crate::generate::Manifest) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut total_image_pages = 0;
+
+    // Home page
+    lines.push("Home → index.html".to_string());
+
+    let tree_nodes = walk_nav_tree(&manifest.navigation);
+    let mut shown_paths = std::collections::HashSet::new();
+
+    for node in &tree_nodes {
+        let prefix = format!("{}{}", indent(node.depth), format_index(node.position));
+
+        if node.is_container {
+            lines.push(format!(
+                "{} {}",
+                prefix,
+                node.path.split('/').next_back().unwrap_or(&node.path)
+            ));
+        } else if let Some(album) = manifest.albums.iter().find(|a| a.path == node.path) {
+            shown_paths.insert(&album.path);
+            lines.push(format!(
+                "{} {} → {}/index.html",
+                prefix, album.title, album.path
+            ));
+
+            for (idx, image) in album.images.iter().enumerate() {
+                let page_url = crate::generate::image_page_url(
+                    idx + 1,
+                    album.images.len(),
+                    image.title.as_deref(),
+                );
+                lines.push(format!(
+                    "{}    → {}/{}index.html",
+                    indent(node.depth),
+                    album.path,
+                    page_url
+                ));
+                total_image_pages += 1;
+            }
+        }
+    }
+
+    // Un-navigated albums
+    for album in &manifest.albums {
+        if !shown_paths.contains(&album.path) {
+            lines.push(format!("    {} → {}/index.html", album.title, album.path));
+
+            for (idx, image) in album.images.iter().enumerate() {
+                let page_url = crate::generate::image_page_url(
+                    idx + 1,
+                    album.images.len(),
+                    image.title.as_deref(),
+                );
+                lines.push(format!("        → {}/{}index.html", album.path, page_url));
+                total_image_pages += 1;
+            }
+        }
+    }
+
+    // Pages
+    for page in &manifest.pages {
+        if page.is_link {
+            lines.push(format!("{} → (external)", page.title));
+        } else {
+            lines.push(format!("{} → {}.html", page.title, page.slug));
+        }
+    }
+
+    let page_count = manifest.pages.iter().filter(|p| !p.is_link).count();
+    lines.push(format!(
+        "Generated {} albums, {} image pages, {} pages",
+        manifest.albums.len(),
+        total_image_pages,
+        page_count
+    ));
+
+    lines
+}
+
+/// Print generate output to stdout.
+pub fn print_generate_output(manifest: &crate::generate::Manifest) {
+    for line in format_generate_output(manifest) {
+        println!("{}", line);
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_html_tags_removes_tags() {
+        assert_eq!(strip_html_tags("<p>Hello <b>world</b></p>"), "Hello world");
+    }
+
+    #[test]
+    fn strip_html_tags_no_tags() {
+        assert_eq!(strip_html_tags("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strip_html_tags_empty() {
+        assert_eq!(strip_html_tags(""), "");
+    }
+
+    #[test]
+    fn strip_html_tags_nested() {
+        assert_eq!(
+            strip_html_tags("<div><p>Some <em>text</em></p></div>"),
+            "Some text"
+        );
+    }
+
+    #[test]
+    fn truncate_desc_short() {
+        assert_eq!(truncate_desc("Short text", 40), "Short text");
+    }
+
+    #[test]
+    fn truncate_desc_exact() {
+        let text = "a".repeat(40);
+        assert_eq!(truncate_desc(&text, 40), text);
+    }
+
+    #[test]
+    fn truncate_desc_long() {
+        let text = "a".repeat(50);
+        let expected = format!("{}...", "a".repeat(40));
+        assert_eq!(truncate_desc(&text, 40), expected);
+    }
+
+    #[test]
+    fn truncate_desc_empty() {
+        assert_eq!(truncate_desc("", 40), "");
+    }
+
+    #[test]
+    fn format_index_single_digit() {
+        assert_eq!(format_index(1), "001");
+    }
+
+    #[test]
+    fn format_index_double_digit() {
+        assert_eq!(format_index(42), "042");
+    }
+
+    #[test]
+    fn format_index_triple_digit() {
+        assert_eq!(format_index(100), "100");
+    }
+
+    #[test]
+    fn walk_nav_tree_empty() {
+        let nodes = walk_nav_tree(&[]);
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn walk_nav_tree_flat() {
+        let nav = vec![
+            NavItem {
+                title: "A".to_string(),
+                path: "a".to_string(),
+                source_dir: "010-A".to_string(),
+                children: vec![],
+            },
+            NavItem {
+                title: "B".to_string(),
+                path: "b".to_string(),
+                source_dir: "020-B".to_string(),
+                children: vec![],
+            },
+        ];
+        let nodes = walk_nav_tree(&nav);
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].position, 1);
+        assert_eq!(nodes[0].depth, 0);
+        assert_eq!(nodes[0].path, "a");
+        assert!(!nodes[0].is_container);
+        assert_eq!(nodes[1].position, 2);
+        assert_eq!(nodes[1].depth, 0);
+    }
+
+    #[test]
+    fn walk_nav_tree_nested() {
+        let nav = vec![NavItem {
+            title: "Parent".to_string(),
+            path: "parent".to_string(),
+            source_dir: "010-Parent".to_string(),
+            children: vec![
+                NavItem {
+                    title: "Child A".to_string(),
+                    path: "parent/child-a".to_string(),
+                    source_dir: "010-Child-A".to_string(),
+                    children: vec![],
+                },
+                NavItem {
+                    title: "Child B".to_string(),
+                    path: "parent/child-b".to_string(),
+                    source_dir: "020-Child-B".to_string(),
+                    children: vec![],
+                },
+            ],
+        }];
+        let nodes = walk_nav_tree(&nav);
+        assert_eq!(nodes.len(), 3);
+        // Parent
+        assert_eq!(nodes[0].position, 1);
+        assert_eq!(nodes[0].depth, 0);
+        assert!(nodes[0].is_container);
+        // Child A
+        assert_eq!(nodes[1].position, 1);
+        assert_eq!(nodes[1].depth, 1);
+        assert!(!nodes[1].is_container);
+        // Child B
+        assert_eq!(nodes[2].position, 2);
+        assert_eq!(nodes[2].depth, 1);
+    }
+
+    #[test]
+    fn indent_zero() {
+        assert_eq!(indent(0), "");
+    }
+
+    #[test]
+    fn indent_one() {
+        assert_eq!(indent(1), "    ");
+    }
+
+    #[test]
+    fn indent_two() {
+        assert_eq!(indent(2), "        ");
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -106,6 +106,8 @@ pub struct InputAlbum {
     pub images: Vec<InputImage>,
     pub in_nav: bool,
     pub config: SiteConfig,
+    #[serde(default)]
+    pub support_files: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -142,6 +144,8 @@ pub struct OutputAlbum {
     pub images: Vec<OutputImage>,
     pub in_nav: bool,
     pub config: SiteConfig,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub support_files: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -192,8 +196,6 @@ pub fn process_with_backend(
     let mut output_albums = Vec::new();
 
     for album in &input.albums {
-        println!("Processing album: {}", album.title);
-
         // Per-album config from the resolved config chain
         let album_process = ProcessConfig::from_site_config(&album.config);
 
@@ -220,8 +222,6 @@ pub fn process_with_backend(
                 if !source_path.exists() {
                     return Err(ProcessError::SourceNotFound(source_path));
                 }
-
-                println!("  {} ", image.filename);
 
                 let dimensions = get_dimensions(backend, &source_path)?;
 
@@ -326,6 +326,7 @@ pub fn process_with_backend(
             images: output_images,
             in_nav: album.in_nav,
             config: album.config.clone(),
+            support_files: album.support_files.clone(),
         });
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,8 @@ pub struct Page {
 pub struct NavItem {
     pub title: String,
     pub path: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source_dir: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<NavItem>,
 }


### PR DESCRIPTION
## Summary
- Replace ad-hoc `println!` calls scattered across `main.rs`, `process.rs`, and `generate.rs` with a centralized `output` module
- Tree-based output shows gallery hierarchy with 3-digit positional indices, photo counts, source directories, and truncated descriptions
- Each pipeline stage gets tailored formatting: source files for scan, generated sizes for process, output paths for generate

## Test plan
- [x] All 295 existing tests pass (new struct fields have serde defaults)
- [x] Visual check: `cargo run -- scan --source fixtures/content` shows structured tree output
- [x] Unit tests added for `strip_html_tags`, `truncate_desc`, `format_index`, `walk_nav_tree`
- [x] Pre-commit hooks pass (rustfmt + clippy + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)