### PR TITLE
Add check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `check` command: validate content directory without building (`simple-gal check`)
+
 ## [0.4.1] - 2026-02-16
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@
 //! # Full build (defaults: --source content --output dist)
 //! simple-gal build
 //!
+//! # Validate content without building
+//! simple-gal check
+//!
 //! # Or run stages individually
 //! simple-gal scan
 //! simple-gal process
@@ -136,6 +139,8 @@ enum Command {
     Generate,
     /// Run the full pipeline: scan → process → generate
     Build,
+    /// Validate content directory without building
+    Check,
     /// Print a stock config.toml with all options documented
     GenConfig,
 }
@@ -214,6 +219,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output::print_generate_output(&gen_manifest);
 
             println!("==> Build complete: {}", cli.output.display());
+        }
+        Command::Check => {
+            let source = resolve_build_source(&cli.source);
+            println!("==> Checking {}", source.display());
+            let manifest = scan::scan(&source)?;
+            output::print_scan_output(&manifest, &source);
+            println!("==> Content is valid");
         }
         Command::GenConfig => {
             print!("{}", config::stock_config_toml());


### PR DESCRIPTION
## Summary
- Adds `simple-gal check` command that validates the content directory without building
- Runs the scan phase (config.toml parsing, structure validation) and reports success or failure
- No manifest files written, no images processed — pure validation

## Test plan
- [x] All 295 existing tests pass
- [x] `cargo run -- check --source fixtures/content` reports valid content
- [x] Invalid content (bad config, mixed dirs, duplicate numbers) propagates errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)