### PR TITLE
Add site description to index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Site description on the index page: a `site.md` (or `.txt`) file in the content root is rendered on the home page with the site title, using the same expandable description pattern as album pages
+- `site_description_file` config option to customize the description filename (default: `"site"`)
+- Desktop 2-column layout for index page when a site description is present (description sidebar + album grid)
+
 ## [0.4.2] - 2026-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Galleries and images are ordered by a numeric prefix (e.g. `001-Paris`, `002-Lon
 - **Photo title**: from the IPTC tag if available, otherwise the filename (e.g. `003-Dusk.jpg` becomes "Dusk").
 - **Photo description**: from the IPTC tag if available, otherwise from a same-name `.txt` sidecar (e.g. `003-Dusk.txt`).
 - **Gallery names**: from the directory name. Descriptions from `description.md` (or `.txt`) inside the directory.
+- **Site description**: a `site.md` (or `site.txt`) in the content root is rendered on the home page with the site title. Configurable via `site_description_file` in `config.toml`.
 
 A `config.toml` in the content root sets global preferences. Each gallery can have its own `config.toml` — only changed properties need to be listed; the rest are inherited from parents.
 
@@ -59,6 +60,7 @@ Any `NNN-<name>.md` file in the content root is added as a page in the navigatio
 ```text
 content/
 ├── config.toml                    # Site configuration (optional)
+├── site.md                        # Site description → rendered on home page
 ├── assets/                        # Static assets → copied to output root
 │   ├── favicon.ico                # Auto-detected, injected into <head>
 │   └── fonts/                     # Custom fonts (referenced in config.toml)
@@ -142,9 +144,19 @@ Every generated site is a Progressive Web App out of the box — no configuratio
 - **App-like display**: opens in standalone mode (no browser chrome), matching the gallery's clean aesthetic.
 - **Automatic updates**: when you rebuild and deploy, the service worker picks up the new version on the next visit.
 
-The gallery name on the home screen comes from `site_title` in your `config.toml`. Default PWA icons are provided; override them by placing `icon-192.png`, `icon-512.png`, or `apple-touch-icon.png` in your `assets/` directory.
+### How it works
 
-**Note**: the site must be deployed at the root of its domain (e.g. `photos.example.com/`, not `example.com/photos/`).
+A **service worker** (`sw.js`) is registered on every page. It uses a stale-while-revalidate caching strategy: cached pages are served instantly while a fresh copy is fetched in the background. The cache name includes the build version (`simple-gal-v<version>`) so old caches are automatically cleaned up when you deploy a new build.
+
+A **web manifest** (`site.webmanifest`) is generated with your `site_title` and default icons. It tells the browser how to display the app when installed: standalone mode, white theme, and your gallery title on the home screen.
+
+### Customizing
+
+- **App name**: set `site_title` in `config.toml` — this becomes the name on the home screen.
+- **Icons**: place `icon-192.png`, `icon-512.png`, or `apple-touch-icon.png` in your `assets/` directory to override the defaults.
+- **Theme color**: the manifest uses white (`#ffffff`) for both `theme_color` and `background_color`. To customize, place your own `site.webmanifest` in `assets/` — it will overwrite the generated one.
+
+**Note**: the site must be deployed at the root of its domain (e.g. `photos.example.com/`, not `example.com/photos/`). Subdirectory deployment is not supported because the service worker scope, manifest paths, and cached asset URLs all assume root-relative paths.
 
 ## GitHub Action
 

--- a/fixtures/content/site.md
+++ b/fixtures/content/site.md
@@ -1,0 +1,3 @@
+A curated collection of **fine art photography** spanning landscapes, travel, and minimalist compositions.
+
+Explore the galleries to see the world through a different lens.

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,10 @@ pub struct SiteConfig {
     /// Contents are copied verbatim to the output root during generation.
     #[serde(default = "default_assets_dir")]
     pub assets_dir: String,
+    /// Stem of the site description file in the content root (e.g. "site" →
+    /// looks for `site.md` / `site.txt`). Rendered on the index page.
+    #[serde(default = "default_site_description_file")]
+    pub site_description_file: String,
     /// Color schemes for light and dark modes.
     pub colors: ColorConfig,
     /// Thumbnail generation settings (aspect ratio).
@@ -144,6 +148,7 @@ pub struct PartialSiteConfig {
     pub content_root: Option<String>,
     pub site_title: Option<String>,
     pub assets_dir: Option<String>,
+    pub site_description_file: Option<String>,
     pub colors: Option<PartialColorConfig>,
     pub thumbnails: Option<PartialThumbnailsConfig>,
     pub images: Option<PartialImagesConfig>,
@@ -164,12 +169,17 @@ fn default_assets_dir() -> String {
     "assets".to_string()
 }
 
+fn default_site_description_file() -> String {
+    "site".to_string()
+}
+
 impl Default for SiteConfig {
     fn default() -> Self {
         Self {
             content_root: default_content_root(),
             site_title: default_site_title(),
             assets_dir: default_assets_dir(),
+            site_description_file: default_site_description_file(),
             colors: ColorConfig::default(),
             thumbnails: ThumbnailsConfig::default(),
             images: ImagesConfig::default(),
@@ -211,6 +221,9 @@ impl SiteConfig {
         }
         if let Some(ad) = other.assets_dir {
             self.assets_dir = ad;
+        }
+        if let Some(sd) = other.site_description_file {
+            self.site_description_file = sd;
         }
         if let Some(c) = other.colors {
             self.colors = self.colors.merge(c);
@@ -779,6 +792,10 @@ site_title = "Gallery"
 # Contents are copied verbatim to the output root during generation.
 # If the directory doesn't exist, it is silently skipped.
 assets_dir = "assets"
+
+# Stem of the site description file in the content root.
+# If site.md or site.txt exists, its content is rendered on the index page.
+# site_description_file = "site"
 
 # ---------------------------------------------------------------------------
 # Thumbnail generation
@@ -1650,6 +1667,31 @@ quality = 200
         let partial: PartialSiteConfig = toml::from_str("[images]\nquality = 70\n").unwrap();
         let config = SiteConfig::default().merge(partial);
         assert_eq!(config.assets_dir, "assets");
+    }
+
+    // =========================================================================
+    // Site description file tests
+    // =========================================================================
+
+    #[test]
+    fn default_site_description_file() {
+        let config = SiteConfig::default();
+        assert_eq!(config.site_description_file, "site");
+    }
+
+    #[test]
+    fn parse_custom_site_description_file() {
+        let toml = r#"site_description_file = "intro""#;
+        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
+        let config = SiteConfig::default().merge(partial);
+        assert_eq!(config.site_description_file, "intro");
+    }
+
+    #[test]
+    fn merge_preserves_default_site_description_file() {
+        let partial: PartialSiteConfig = toml::from_str("[images]\nquality = 70\n").unwrap();
+        let config = SiteConfig::default().merge(partial);
+        assert_eq!(config.site_description_file, "site");
     }
 
     // =========================================================================

--- a/src/process.rs
+++ b/src/process.rs
@@ -94,6 +94,8 @@ pub struct InputManifest {
     pub albums: Vec<InputAlbum>,
     #[serde(default)]
     pub pages: Vec<Page>,
+    #[serde(default)]
+    pub description: Option<String>,
     pub config: SiteConfig,
 }
 
@@ -130,6 +132,8 @@ pub struct OutputManifest {
     pub albums: Vec<OutputAlbum>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pages: Vec<Page>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub config: SiteConfig,
 }
 
@@ -334,6 +338,7 @@ pub fn process_with_backend(
         navigation: input.navigation,
         albums: output_albums,
         pages: input.pages,
+        description: input.description,
         config: input.config,
     })
 }

--- a/static/style.css
+++ b/static/style.css
@@ -260,6 +260,17 @@ main {
     max-width: 1200px;
 }
 
+.index-header {
+    padding-left: var(--grid-padding);
+    margin-bottom: 0;
+}
+
+.index-header h1 {
+    font-size: var(--font-size-heading);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
 .album-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -519,6 +530,24 @@ body.has-description .image-nav {
     }
 
     .album-description {
+        max-width: none;
+    }
+
+    .index-page.has-description {
+        display: grid;
+        grid-template-columns: 2fr 5fr;
+        gap: 0 var(--thumbnail-gap);
+    }
+
+    .index-page.has-description .index-header {
+        position: sticky;
+        top: calc(var(--header-height) + 2rem);
+        align-self: start;
+        padding-left: var(--grid-padding);
+        padding-top: var(--grid-padding);
+    }
+
+    .index-page.has-description .album-description {
         max-width: none;
     }
 }


### PR DESCRIPTION
## Summary
- Adds a configurable site description file (`site.md`/`.txt`) that renders on the home page using the same expandable description pattern as album pages
- New `site_description_file` config option (default: `"site"`) to customize the filename
- Desktop 2-column layout (description sidebar + album grid) when a site description is present
- Generalized `read_description()` helper shared between site and album description reading
- 14 new tests covering config, scan, and generate stages

## Test plan
- [x] All 309 tests pass (`cargo test`)
- [ ] Build with `fixtures/content` and verify `index.html` contains description markup
- [ ] Visually verify desktop 2-column layout and mobile expand/collapse behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)