### PR TITLE
Fix photo view scrolling with descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `site_description_file` config option to customize the description filename (default: `"site"`)
 - Desktop 2-column layout for index page when a site description is present (description sidebar + album grid)
 
+### Fixed
+- Photo view scrolling broken when description present: invisible click-navigation zones (prev/next) were siblings of `<main>`, intercepting scroll events over 60% of the viewport — moved them inside `<main>` so scroll events propagate to the scrollable container
+
 ## [0.4.2] - 2026-02-16
 
 ### Added

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -908,9 +908,9 @@ fn render_image_page(
                     }
                 }
             }
+            a.nav-prev href=(prev_url) aria-label="Previous image" {}
+            a.nav-next href=(next_url) aria-label="Next image" {}
         }
-        a.nav-prev href=(prev_url) aria-label="Previous image" {}
-        a.nav-next href=(next_url) aria-label="Next image" {}
         script { (PreEscaped(JS)) }
     };
 


### PR DESCRIPTION
## Summary
- Invisible prev/next click-navigation zones (`<a class="nav-prev/next">`) were siblings of `<main>`, so scroll events over those areas (60% of the viewport) hit `<body>` (`overflow: hidden`) instead of the scrollable `<main>` (`overflow-y: auto`)
- Moved the nav zones inside `<main>` — since they're `position: fixed`, visual position is unchanged, but scroll events now propagate correctly
- This fixes both "can't scroll at all" (pointer over nav zones) and "locks to final position" (pointer drifts to nav zone after scrolling down)

## Test plan
- [ ] Open a photo with a long description — verify the description scrolls smoothly
- [ ] Scroll down then back up — verify bidirectional scrolling works
- [ ] Verify prev/next click navigation still works (click left/right sides of viewport)
- [ ] Verify keyboard navigation (arrow keys, Escape) still works
- [ ] Test on mobile — verify touch scrolling and swipe navigation both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)