### PR TITLE
Fix: derive image format support from backend capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Image format list now derived from actual decode capabilities instead of a hardcoded list; AVIF removed as input format until decoder is added
+
 ## [0.7.0] - 2026-02-20
 
 ### Added

--- a/src/imaging/mod.rs
+++ b/src/imaging/mod.rs
@@ -43,4 +43,4 @@ pub use operations::{
     ResponsiveConfig, ThumbnailConfig, create_responsive_images, create_thumbnail, get_dimensions,
 };
 pub use params::{Quality, Sharpening};
-pub use rust_backend::RustBackend;
+pub use rust_backend::{RustBackend, supported_input_extensions};

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -129,8 +129,6 @@ pub struct Image {
     pub description: Option<String>,
 }
 
-const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "tif", "tiff", "webp", "avif"];
-
 pub fn scan(root: &Path) -> Result<Manifest, ScanError> {
     let mut albums = Vec::new();
     let mut nav_items = Vec::new();
@@ -401,7 +399,7 @@ fn is_image(path: &Path) -> bool {
         .extension()
         .map(|e| e.to_string_lossy().to_lowercase())
         .unwrap_or_default();
-    IMAGE_EXTENSIONS.contains(&ext.as_str())
+    crate::imaging::supported_input_extensions().contains(&ext.as_str())
 }
 
 /// Read a description from `<stem>.md` or `<stem>.txt` in the given directory.


### PR DESCRIPTION
## Summary
- Replace hardcoded `IMAGE_EXTENSIONS` list in `scan.rs` with a dynamically computed list filtered by `ImageFormat::reading_enabled()`
- AVIF excluded from candidates entirely — the `image` crate's `"avif"` feature only enables the **encoder** (rav1e); the decoder requires `"avif-native"` (C library dav1d) which we don't use
- `reading_enabled()` incorrectly returns `true` for AVIF when `"avif"` is enabled, so we cannot rely on that API alone — hence the explicit exclusion

## Changes
- **`src/imaging/rust_backend.rs`** — `PHOTO_CANDIDATES` mapping + `LazyLock` + `supported_input_extensions()` public function
- **`src/imaging/mod.rs`** — re-export `supported_input_extensions`
- **`src/scan.rs`** — removed `IMAGE_EXTENSIONS` constant, `is_image()` now calls the dynamic function
- **`CHANGELOG.md`** — documented fix under `[Unreleased]`

## Test plan
- [x] `supported_extensions_match_decodable_formats` — asserts jpg/jpeg/png/tif/tiff/webp present, avif absent
- [x] All 339 existing tests pass unchanged (fixtures use `.jpg`)
- [ ] `simple-gal check` on a content dir with only `.avif` files should now error (no decodable images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)