### PR TITLE
Fix AVIF parsing of size-0 mdat boxes and --source path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- AVIF files with size-0 `mdat` boxes (common in Lightroom/modern encoders) now parse correctly — works around an `avif-parse` limitation by patching the ISOBMFF header in memory
+- `--source` with absolute/cross-project paths no longer silently scans the wrong directory — relative `content_root` is now resolved against the source path instead of the current working directory
+
+### Changed
+- Upgraded `avif-parse` from 1.x to 2.0.0
+
 ## [0.8.1] - 2026-02-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "avif-parse"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f85ce2a7cd14ac0a30dc29a115de22466aeb8a029410f9f1e4f283443c959d1"
+checksum = "b67bc9916c9267bde6e7dbf9d1baba058a97b4dd82b9c8f5fdde2d6b2cab4e24"
 dependencies = [
  "arrayvec",
  "bitreader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ image = { version = "0.25", default-features = false, features = [
     "jpeg", "png", "tiff", "webp",
     "avif",
 ] }
-avif-parse = "1"
+avif-parse = "2"
 maud = "0.26"
 rav1d = { version = "1", default-features = false, features = ["bitdepth_8", "bitdepth_16"] }
 pulldown-cmark = "0.13"


### PR DESCRIPTION
## Summary
- Work around `avif-parse` rejecting valid ISOBMFF `size == 0` boxes (common in Lightroom/modern AVIF encoders) by patching the `mdat` header in memory before parsing
- Fix `resolve_build_source` resolving relative `content_root` against CWD instead of the `--source` path, which silently scanned the wrong directory when invoked from outside the project
- Upgrade `avif-parse` from 1.x to 2.0.0

## Context

The ISOBMFF workaround is documented inline with a link to the upstream source:
https://github.com/kornelski/avif-parse/blob/v2.0.0/src/lib.rs#L663

No upstream issue exists yet. Once `avif-parse` handles `size == 0` boxes natively, `fix_unsized_isobmff_boxes` can be removed.

## Test plan
- [x] All 342 unit tests pass
- [x] Full build of photo.debert.xyz content (75 AVIF images, 2 albums) succeeds from the simple-gal directory using `--source /abs/path`
- [x] `check` command validates content without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)