### PR TITLE
Stream process stage output as images complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Image processing now streams progress to the terminal as each image completes, instead of waiting for the entire stage to finish before printing output. Uses an `mpsc` channel from the process module to a printer thread, preserving the separation between processing logic and output formatting.
+
 ## [0.8.2] - 2026-02-20
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Image processing now emits `ProcessEvent` values through an `mpsc` channel as each image finishes, instead of collecting all results then printing at the end
- A dedicated printer thread in `main.rs` receives events and formats them via `output::format_process_event()`, giving real-time terminal feedback during long builds
- Removed the batch `format_process_output` / `print_process_output` functions (dead code after this change)

## Design
The `process` / `process_with_backend` functions accept an `Option<Sender<ProcessEvent>>`. Two event types:
- `AlbumStarted { title, image_count }` — emitted before each album's parallel processing begins
- `ImageProcessed { title, sizes }` — emitted as each image completes (from rayon worker threads)

The channel serializes events naturally — the single receiver thread prints them sequentially, so no mutex on stdout is needed. Tests pass `None` for the progress parameter.

## Test plan
- [x] All 342 existing tests pass (pre-commit hook runs fmt + clippy + tests)
- [ ] Manual test with a real gallery to verify streaming output appears line-by-line during processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)