### PR TITLE
Fix view transitions broken by service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- View transitions broken with PWA: service worker's `respondWith()` on navigation requests interfered with the CSS View Transitions API (`@view-transition { navigation: auto }`), causing abrupt page swaps instead of smooth fades when images weren't cached. Navigation requests now pass through to the browser natively.
+
+### Removed
+- Offline fallback page (`offline.html`) — no longer generated since navigation requests are not intercepted by the service worker
+
 ## [0.8.3] - 2026-02-20
 
 ### Changed

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -338,10 +338,6 @@ pub fn generate(
     );
     fs::write(output_dir.join("index.html"), index_html.into_string())?;
 
-    // Generate offline fallback page (served by SW when offline and page not cached)
-    let offline_html = render_offline(&css, favicon_href.as_deref(), &snippets);
-    fs::write(output_dir.join("offline.html"), offline_html.into_string())?;
-
     // Generate pages (content pages only, not link pages)
     for page in manifest.pages.iter().filter(|p| !p.is_link) {
         let page_html = render_page(
@@ -964,35 +960,6 @@ fn render_page(
         &page.title,
         css,
         font_url,
-        None,
-        None,
-        favicon_href,
-        snippets,
-        content,
-    )
-}
-
-/// Renders a minimal offline fallback page.
-///
-/// Served by the service worker when the user is offline and the requested
-/// page is not in the cache. Uses the site's CSS so it matches the gallery
-/// look-and-feel. No navigation or font URL — the page must work with only
-/// the pre-cached assets.
-fn render_offline(css: &str, favicon_href: Option<&str>, snippets: &CustomSnippets) -> Markup {
-    let content = html! {
-        main.page {
-            article.page-content {
-                h1 { "You're offline" }
-                p { "This page hasn't been cached yet. Connect to the internet or go back to a page you've already visited." }
-                p { a href="/" { "Go to the gallery" } }
-            }
-        }
-    };
-
-    base_document(
-        "Offline",
-        css,
-        None,
         None,
         None,
         favicon_href,

--- a/tests/browser_sw.rs
+++ b/tests/browser_sw.rs
@@ -214,10 +214,6 @@ fn sw_caches_core_assets_on_install() {
         "should cache /index.html, got: {urls:?}"
     );
     assert!(
-        urls.contains(&"/offline.html".to_string()),
-        "should cache /offline.html, got: {urls:?}"
-    );
-    assert!(
         urls.contains(&"/site.webmanifest".to_string()),
         "should cache /site.webmanifest, got: {urls:?}"
     );


### PR DESCRIPTION
## Summary
- Service worker's `respondWith()` on navigation requests was interfering with the CSS View Transitions API (`@view-transition { navigation: auto }`), causing abrupt page swaps instead of smooth fades when navigating to non-cached photos
- Navigation requests now pass through to the browser natively, preserving cross-document view transitions
- Removed dead `offline.html` fallback page (no longer served since navigations aren't intercepted)

## Test plan
- [x] All 342 unit/integration tests pass
- [x] Browser tests (PWA, SW, layout) compile and are unchanged in behavior (pre-existing fixture path issue on `main` is unrelated)
- [ ] Manual: navigate between photos — smooth fade transition should work consistently regardless of cache state

🤖 Generated with [Claude Code](https://claude.com/claude-code)