### PR TITLE
Fix nav click zones to overlap image edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - View transitions broken with PWA: service worker's `respondWith()` on navigation requests interfered with the CSS View Transitions API (`@view-transition { navigation: auto }`), causing abrupt page swaps instead of smooth fades when images weren't cached. Navigation requests now pass through to the browser natively.
+- Navigation click zones (prev/next) now overlap 20% of the image and extend to the page edges, instead of using a fixed 30% viewport width. On wide screens with portrait images, the old zones were entirely in the mat area and hard to find; the zones now always start at the image edges.
 
 ### Removed
 - Offline fallback page (`offline.html`) — no longer generated since navigation requests are not intercepted by the service worker

--- a/fixtures/browser-content/config.toml
+++ b/fixtures/browser-content/config.toml
@@ -1,2 +1,2 @@
 # Browser test fixture config
-content_root = "fixtures/browser-content"
+content_root = "browser-content"

--- a/static/nav.js
+++ b/static/nav.js
@@ -6,6 +6,21 @@
     var prevUrl = prev && prev.getAttribute('href');
     var nextUrl = next && next.getAttribute('href');
 
+    // Position click zones so they overlap ~20% of the image on each side
+    // and extend outward to the page edges.
+    var frame = document.querySelector('.image-frame');
+    if (frame) {
+        var OVERLAP = 0.2;
+        function sizeNavZones() {
+            var r = frame.getBoundingClientRect();
+            if (r.width === 0) return;
+            if (prev) prev.style.width = (r.left + r.width * OVERLAP) + 'px';
+            if (next) next.style.width = (window.innerWidth - r.right + r.width * OVERLAP) + 'px';
+        }
+        sizeNavZones();
+        window.addEventListener('resize', sizeNavZones);
+    }
+
     // Keyboard navigation
     document.addEventListener('keydown', function(e) {
         if (e.key === 'ArrowLeft' || e.key === 'h') {

--- a/static/style.css
+++ b/static/style.css
@@ -414,6 +414,8 @@ body.image-view main {
 }
 
 /* Click navigation zones (invisible prev/next links) */
+/* Width is set dynamically by nav.js to overlap 20% of the image;
+   the 30% fallback applies when JS is unavailable. */
 .nav-prev,
 .nav-next {
     position: fixed;

--- a/tests/browser_layout.rs
+++ b/tests/browser_layout.rs
@@ -430,3 +430,53 @@ fn nav_dots_bottom_anchored_with_caption() {
         vh * 0.75
     );
 }
+
+// ===========================================================================
+// Navigation click zones overlap with image edges
+// ===========================================================================
+
+#[test]
+#[ignore]
+fn nav_zones_overlap_image_portrait_wide_viewport() {
+    // Wide viewport + portrait image: the image is narrow and centered,
+    // so the click zones should extend from the page edges into the image.
+    let tab = load_page_with_viewport(page::with_caption::PORTRAIT, &[], 1920, 1080);
+    let frame = bounding_box(&tab, ".image-frame");
+    let prev = bounding_box(&tab, ".nav-prev");
+    let next = bounding_box(&tab, ".nav-next");
+    let vw: f64 = 1920.0;
+    let overlap = 0.2;
+
+    let expected_prev_right = frame.x + frame.width * overlap;
+    let expected_next_left = frame.x + frame.width * (1.0 - overlap);
+
+    // .nav-prev: left edge at 0, right edge 20% into the image
+    assert_close(prev.x, 0.0, 1.0);
+    assert_close(prev.x + prev.width, expected_prev_right, 2.0);
+
+    // .nav-next: left edge at 80% of image, right edge at viewport edge
+    assert_close(next.x, expected_next_left, 2.0);
+    assert_close(next.x + next.width, vw, 2.0);
+}
+
+#[test]
+#[ignore]
+fn nav_zones_overlap_image_landscape() {
+    let tab = load_page(page::no_description::LANDSCAPE, &[]);
+    let frame = bounding_box(&tab, ".image-frame");
+    let prev = bounding_box(&tab, ".nav-prev");
+    let next = bounding_box(&tab, ".nav-next");
+    let vw: f64 = 1280.0;
+    let overlap = 0.2;
+
+    let expected_prev_right = frame.x + frame.width * overlap;
+    let expected_next_left = frame.x + frame.width * (1.0 - overlap);
+
+    // .nav-prev: left edge at 0, right edge 20% into the image
+    assert_close(prev.x, 0.0, 1.0);
+    assert_close(prev.x + prev.width, expected_prev_right, 2.0);
+
+    // .nav-next: left edge at 80% of image, right edge at viewport edge
+    assert_close(next.x, expected_next_left, 2.0);
+    assert_close(next.x + next.width, vw, 2.0);
+}


### PR DESCRIPTION
## Summary
- Navigation click zones (prev/next) now dynamically size based on the image frame position instead of using a fixed 30% of viewport width
- Zones overlap 20% of the image on each side and extend outward to the page edges, so they're always reachable from the image itself
- On wide desktops with portrait images, the old zones were entirely in the mat area and hard to discover; now they always start at the image edges
- Also fixes the browser test fixture `content_root` path that was broken since the 0.8.2 `--source` path resolution change

## Test plan
- [x] All 342 unit tests pass
- [x] All 18 browser layout tests pass (including 2 new ones)
- [x] `nav_zones_overlap_image_portrait_wide_viewport` — verifies zones at 1920x1080 with a portrait image
- [x] `nav_zones_overlap_image_landscape` — verifies zones at 1280x800 with a landscape image

🤖 Generated with [Claude Code](https://claude.com/claude-code)