### PR TITLE
Exclude thumb images from gallery image list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Thumb-designated images (`NNN-thumb.<ext>`) are no longer included as browsable gallery images — they are now used exclusively as the album's representative thumbnail on the index page
+
 ## [0.8.4] - 2026-02-21
 
 ### Fixed

--- a/docs/src/images/thumbnails.md
+++ b/docs/src/images/thumbnails.md
@@ -103,20 +103,18 @@ content/010-Landscapes/
 └── 010-night.jpg
 ```
 
-The thumb image is still a normal gallery image — it appears in the album alongside every other photo. It is simply also used as the album's representative thumbnail on the index page.
+The thumb image is **not** included in the gallery — it is only used as the album's representative thumbnail on the index page. It does not appear as a browsable photo in the album.
 
 ### Naming rules
 
 Any image whose name (after the number prefix) starts with `thumb` is a thumb designator:
 
-| Filename | Thumb? | Image title |
-|----------|--------|-------------|
-| `005-thumb.jpg` | Yes | (none) |
-| `005-thumb-The-Sunset.jpg` | Yes | The Sunset |
-| `thumb.jpg` | Yes | (none) |
-| `001-thumbnail.jpg` | No | thumbnail |
-
-The `thumb` prefix is stripped from the image's display title. `005-thumb-The-Sunset.jpg` becomes "The Sunset", not "thumb The Sunset".
+| Filename | Thumb? |
+|----------|--------|
+| `005-thumb.jpg` | Yes |
+| `005-thumb-The-Sunset.jpg` | Yes |
+| `thumb.jpg` | Yes |
+| `001-thumbnail.jpg` | No |
 
 Only one thumb image is allowed per album. If two or more images match, the build fails with a `DuplicateThumb` error.
 


### PR DESCRIPTION
## Summary
- Thumb-designated images (`NNN-thumb.<ext>`) are no longer included as browsable gallery images — they now only serve as the album's representative thumbnail on the index page
- When a dedicated thumb exists and isn't in the image list, the process stage generates just the thumbnail for it (no responsive variants or image page)
- Updated docs and changelog

## Test plan
- [x] All 342 unit tests pass (including new `thumb_image_excluded_from_images` and `thumb_image_with_title_excluded_from_images` tests)
- [ ] Build a site with a `NNN-thumb.<ext>` file and verify it appears as album thumbnail but not in the gallery
- [ ] Build a site without a thumb file and verify first-image fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)