### PR TITLE
Content-addressed image processing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Image processing cache is now content-addressed: cache keys use source file hash + encoding parameters instead of output paths. Album renames, file renumbers, and slug changes no longer invalidate the cache — only actual image content or encoding parameter changes trigger re-encoding. When a cached file is found at a different path (e.g. after an album rename), it is copied instead of re-encoded.
+
 ## [0.9.0] - 2026-02-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Cache lookups now use `source_hash:params_hash` content index instead of output paths as keys
- Album renames, file renumbers, and slug changes no longer invalidate the cache
- When a cached file is found at a different path (e.g. after album rename), it is copied instead of re-encoded
- On-disk manifest format unchanged — backward compatible with existing caches

## Test plan
- [x] All 347 existing tests pass
- [x] New unit tests: `find_cached_*`, `insert_removes_stale_entry_on_path_change`, `content_index_rebuilt_on_load`
- [x] New integration test: `cache_hit_after_album_rename` — verifies copies instead of re-encodes
- [ ] Release and verify with photo.debert.xyz deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)