### PR TITLE
Remove redundant content_root config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- `content_root` config key — it was redundant since the config file already lives inside the content directory, so the content root is known by the time the config is found. The `--source` CLI flag is the sole way to specify the content directory.
+
 ## [0.10.0] - 2026-02-21
 
 ### Changed

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -6,13 +6,11 @@ Every configuration key, its type, default value, and purpose. All keys are opti
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `content_root` | string | `"content"` | Path to the content directory. Only meaningful in the root config. |
 | `site_title` | string | `"Gallery"` | Site title used in breadcrumbs and the browser tab for the index page. |
 | `assets_dir` | string | `"assets"` | Directory for static assets (favicon, fonts, etc.), relative to content root. Contents are copied verbatim to the output root. Silently skipped if it does not exist. |
 | `site_description_file` | string | `"site"` | Stem of the site description file in the content root. If `site.md` or `site.txt` exists, its content is rendered on the index page. |
 
 ```toml
-content_root = "content"
 site_title = "My Portfolio"
 assets_dir = "assets"
 site_description_file = "site"

--- a/fixtures/browser-content/config.toml
+++ b/fixtures/browser-content/config.toml
@@ -1,2 +1,1 @@
 # Browser test fixture config
-content_root = "browser-content"

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,9 +113,6 @@ pub enum ConfigError {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct SiteConfig {
-    /// Path to the content root directory (only meaningful at root level).
-    #[serde(default = "default_content_root")]
-    pub content_root: String,
     /// Site title used in breadcrumbs and the browser tab for the home page.
     #[serde(default = "default_site_title")]
     pub site_title: String,
@@ -145,7 +142,6 @@ pub struct SiteConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PartialSiteConfig {
-    pub content_root: Option<String>,
     pub site_title: Option<String>,
     pub assets_dir: Option<String>,
     pub site_description_file: Option<String>,
@@ -155,10 +151,6 @@ pub struct PartialSiteConfig {
     pub theme: Option<PartialThemeConfig>,
     pub font: Option<PartialFontConfig>,
     pub processing: Option<PartialProcessingConfig>,
-}
-
-fn default_content_root() -> String {
-    "content".to_string()
 }
 
 fn default_site_title() -> String {
@@ -176,7 +168,6 @@ fn default_site_description_file() -> String {
 impl Default for SiteConfig {
     fn default() -> Self {
         Self {
-            content_root: default_content_root(),
             site_title: default_site_title(),
             assets_dir: default_assets_dir(),
             site_description_file: default_site_description_file(),
@@ -213,9 +204,6 @@ impl SiteConfig {
 
     /// Merge a partial config on top of this one.
     pub fn merge(mut self, other: PartialSiteConfig) -> Self {
-        if let Some(cr) = other.content_root {
-            self.content_root = cr;
-        }
         if let Some(st) = other.site_title {
             self.site_title = st;
         }
@@ -782,9 +770,6 @@ pub fn stock_config_toml() -> &'static str {
 # Each level only needs the keys it wants to override.
 # Unknown keys will cause an error.
 
-# Path to content directory (only meaningful at root level)
-content_root = "content"
-
 # Site title shown in breadcrumbs and the browser tab for the home page.
 site_title = "Gallery"
 
@@ -997,12 +982,6 @@ mod tests {
         let config = SiteConfig::default();
         assert_eq!(config.colors.light.background, "#ffffff");
         assert_eq!(config.colors.dark.background, "#000000");
-    }
-
-    #[test]
-    fn default_config_has_content_root() {
-        let config = SiteConfig::default();
-        assert_eq!(config.content_root, "content");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output::print_generate_output(&manifest);
         }
         Command::Build(cache_args) => {
-            // Resolve content root: check config.toml in source dir for content_root override
             let source = resolve_build_source(&cli.source);
 
             std::fs::create_dir_all(&cli.temp_dir)?;
@@ -222,23 +221,6 @@ fn init_thread_pool(processing: &config::ProcessingConfig) {
 }
 
 /// Resolve the content source directory for the build command.
-///
-/// Loads `config.toml` from the given source directory and uses its `content_root`
-/// if it specifies a different path. Relative `content_root` values are resolved
-/// against the parent of `cli_source` (since config.toml lives inside the content
-/// directory, `content_root` is relative to the project root).
 fn resolve_build_source(cli_source: &std::path::Path) -> PathBuf {
-    config::load_config(cli_source)
-        .map(|c| {
-            let content_root = PathBuf::from(c.content_root);
-            if content_root.is_absolute() {
-                content_root
-            } else {
-                cli_source
-                    .parent()
-                    .map(|p| p.join(&content_root))
-                    .unwrap_or(content_root)
-            }
-        })
-        .unwrap_or_else(|_| cli_source.to_path_buf())
+    cli_source.to_path_buf()
 }


### PR DESCRIPTION
## Summary
- Removes the `content_root` config key from `SiteConfig`, `PartialSiteConfig`, stock config, docs, and fixtures
- Simplifies `resolve_build_source()` in `main.rs` — no longer loads config to redirect the content directory
- The setting was circular: the config file lives inside the content directory, so by the time it's found the content root is already known. `--source` is the sole way to specify it.

## Test plan
- [x] All 346 unit tests pass
- [x] Pre-commit hooks (fmt, clippy, tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)