### PR TITLE
Fix: keep thumb-designated images in gallery

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -442,39 +442,13 @@ pub fn process_with_backend(
         // Sort by number to ensure consistent ordering
         output_images.sort_by_key(|img| img.number);
 
-        // Find album thumbnail: match the preview_image from scan, fall back to first.
-        // If the preview_image is a dedicated thumb file (not in the image list),
-        // generate just a thumbnail for it.
-        let album_thumbnail = if let Some(img) = output_images
+        // Find album thumbnail: the preview_image is always in the image list.
+        let album_thumbnail = output_images
             .iter()
             .find(|img| img.source_path == album.preview_image)
-        {
-            img.thumbnail.clone()
-        } else {
-            // Dedicated thumb file — process only its thumbnail
-            let thumb_source = source_root.join(&album.preview_image);
-            let stem = Path::new(&album.preview_image)
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .unwrap();
-            let source_hash = cache::hash_file(&thumb_source)?;
-            let ctx = CacheContext {
-                source_hash: &source_hash,
-                cache: &cache,
-                stats: &stats,
-                cache_root: output_dir,
-            };
-            let (path, _status) = create_thumbnail_cached(
-                backend,
-                &thumb_source,
-                &album_output_dir,
-                stem,
-                &thumbnail_config,
-                &ctx,
-            )?;
-            path
-        };
+            .expect("preview_image must be in the image list")
+            .thumbnail
+            .clone();
 
         output_albums.push(OutputAlbum {
             path: album.path.clone(),


### PR DESCRIPTION
## Summary
- Thumb-designated images (e.g. `005-thumb.jpg`, `005-thumb-The-Sunset.jpg`) were being removed from the album's image list, making them invisible in the gallery
- Now they remain in the gallery as normal images while also serving as the album preview thumbnail
- Removed dead code in `process.rs` that handled the "dedicated thumb not in image list" case

## Test plan
- [x] Updated `thumb_image_excluded_from_images` → `thumb_image_included_in_images` (verifies 3 images including thumb)
- [x] Updated `thumb_image_with_title_excluded_from_images` → `thumb_image_with_title_included_in_images`
- [x] Updated `images_sorted_by_number`, `fixture_image_sidecar_read`, `fixture_image_titles` for new count
- [x] All 354 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)