### PR TITLE
Add nested gallery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Nested gallery support: container directories (directories with sub-albums but no images) now generate their own gallery-list pages showing thumbnail cards for each child album/container
+- `description` field on `NavItem` — container directories can have `description.md`/`description.txt` shown on their gallery-list page
+- Breadcrumbs reflect nesting: album pages show `Home › NY › Snow` instead of `Home › Snow`, and image pages include the full chain
+
+### Changed
+- Index page now shows only top-level navigation entries instead of all albums flat — nested albums appear under their container
+- Navigation containers are clickable links to their gallery-list page instead of inert `<span>` labels
+- Index page and container gallery-list pages share a single rendering path (`render_gallery_list_page`)
+
+### Fixed
+- Nested album pages had broken image paths: `strip_prefix` stripped the full nested path instead of just the album directory name, causing double-nested URLs (e.g. `/NY/Night/Night/thumb.avif`)
+
 ## [0.10.2] - 2026-02-21
 
 ## [0.10.1] - 2026-02-21

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -15,7 +15,7 @@
 ## Running tests
 
 ```bash
-cargo test                                          # 253 unit + integration tests
+cargo test                                          # unit + integration tests
 cargo test --test browser_layout -- --ignored       # 12 browser layout tests (needs Chrome)
 cargo test --test browser_pwa -- --ignored          # Browser PWA tests (needs Chrome)
 ```
@@ -73,6 +73,10 @@ All helpers live in `src/test_helpers.rs` (compiled only under `#[cfg(test)]`).
 - **`nav_titles(&manifest)`** → `Vec<&str>` — Top-level nav items.
 - **`nav_children_titles(&manifest, "parent")`** → `Vec<&str>` — Children of a nav item.
 - **`assert_nav_shape(&manifest, &[("Title", &["child1", "child2"])])`** — Assert the full nav tree in one call.
+
+### Nested album helpers
+
+- **`create_nested_test_album()`** — Creates a test `Album` at path `"NY/Night"` with process-stage-convention paths (image paths relative to the album's parent directory, e.g. `Night/001-city-800.avif`). Use this to test that nested album rendering strips path prefixes correctly.
 
 ## Browser tests
 

--- a/docs/src/content/albums-and-groups.md
+++ b/docs/src/content/albums-and-groups.md
@@ -1,0 +1,189 @@
+# Albums and Groups
+
+Simple Gal organizes content into two types of directories: **albums** (which contain images) and **groups** (which contain other directories). This distinction is automatic -- the scanner looks at what a directory contains and classifies it accordingly.
+
+## Albums
+
+An album is any directory that contains image files. It generates a gallery page with a thumbnail grid and individual photo detail pages.
+
+```text
+content/010-Landscapes/
+├── 001-dawn.jpg
+├── 002-dusk.jpg
+└── 010-night.jpg
+```
+
+This produces:
+
+- A gallery page at `/Landscapes/` with thumbnails for all three images
+- Individual photo pages for each image (e.g., `/Landscapes/1-dawn/`)
+
+### Preview image
+
+Each album has a preview image used as its thumbnail on parent pages (the home page or a group page). The preview is selected as follows:
+
+1. The image with number `001` (i.e., number prefix value 1), if it exists
+2. Otherwise, the image with the lowest number prefix
+
+```text
+content/010-Landscapes/
+├── 001-dawn.jpg       # This is the preview (number 1)
+├── 002-dusk.jpg
+└── 010-night.jpg
+```
+
+```text
+content/020-Abstract/
+├── 005-first.jpg      # This is the preview (lowest number, no 001)
+└── 010-second.jpg
+```
+
+Choose your `001` image deliberately -- it represents the album everywhere on the site.
+
+### Album descriptions
+
+An album can have a description displayed above its thumbnail grid. Place a `description.md` or `description.txt` file in the album directory:
+
+```text
+content/010-Landscapes/
+├── description.md     # or description.txt
+├── 001-dawn.jpg
+└── ...
+```
+
+If both files exist, `description.md` takes priority and `description.txt` is ignored.
+
+**`description.md`** is rendered as Markdown:
+
+```markdown
+A week in **Tokyo** and Kyoto -- street photography and temple gardens.
+```
+
+**`description.txt`** is plain text with automatic paragraph handling:
+
+```text
+A collection of landscape photographs from various locations.
+
+Visit https://example.com for more.
+```
+
+Double newlines become `<p>` elements. URLs are automatically linked. HTML characters are escaped.
+
+See [Metadata](metadata.md) for full details on description formatting.
+
+## Groups
+
+A group is a directory that contains subdirectories instead of images. It acts as a container in the navigation hierarchy.
+
+```text
+content/020-Travel/
+├── 010-Japan/
+│   ├── 001-tokyo.jpg
+│   └── 002-kyoto.jpg
+└── 020-Italy/
+    └── 001-rome.jpg
+```
+
+`020-Travel/` is a group. It appears in navigation as a clickable "Travel" link with children "Japan" and "Italy". Clicking it navigates to a gallery-list page at `/Travel/` showing thumbnail cards for each child album or sub-group.
+
+Groups can be nested to any depth:
+
+```text
+content/010-Work/
+├── 010-Commercial/
+│   ├── 010-Fashion/
+│   │   └── 001-photo.jpg
+│   └── 020-Product/
+│       └── 001-photo.jpg
+└── 020-Editorial/
+    └── 001-photo.jpg
+```
+
+### Group descriptions
+
+Like albums, groups can have a `description.md` or `description.txt` file. The description is rendered on the group's gallery-list page above the thumbnail grid.
+
+### Group configuration
+
+Groups can have their own `config.toml` that applies to all albums beneath them. Configuration cascades through the hierarchy:
+
+```text
+content/
+├── config.toml              # Root config
+├── 020-Travel/
+│   ├── config.toml          # Overrides root for all Travel albums
+│   ├── 010-Japan/
+│   │   ├── config.toml      # Overrides Travel config for Japan only
+│   │   └── 001-tokyo.jpg
+│   └── 020-Italy/
+│       └── 001-rome.jpg     # Gets Travel config (no local override)
+```
+
+The merge chain is: **stock defaults** -> **root config** -> **group config** -> **album config**. Each level overrides only the keys it specifies; everything else is inherited.
+
+For example, if the root sets `quality = 85`, the Travel group sets `aspect_ratio = [1, 1]`, and the Japan album sets `quality = 70`:
+
+- Japan gets: `quality = 70` (own), `aspect_ratio = [1, 1]` (group)
+- Italy gets: `quality = 85` (root), `aspect_ratio = [1, 1]` (group)
+
+## The no-mixing rule
+
+A directory cannot contain both images and subdirectories. This is a hard error:
+
+```text
+content/010-Mixed/
+├── 001-photo.jpg      # Image
+└── sub-album/         # Subdirectory
+    └── 001-other.jpg
+```
+
+```text
+Error: Directory contains both images and subdirectories: content/010-Mixed
+```
+
+This rule exists because a directory is either an album (displayed as a gallery) or a group (a navigation container). Mixing the two would create ambiguity about how to render the directory.
+
+To fix this, restructure the content so images and subdirectories live in separate directories:
+
+```text
+content/010-Mixed/
+├── 010-Main/              # Album with the images
+│   └── 001-photo.jpg
+└── 020-Sub-Album/         # Another album
+    └── 001-other.jpg
+```
+
+## Navigation structure
+
+The navigation tree is built from numbered directories:
+
+```text
+content/
+├── 010-Landscapes/           # Nav: "Landscapes"
+├── 020-Travel/               # Nav: "Travel" (group)
+│   ├── 010-Japan/            #   Nav: "Japan" (child)
+│   └── 020-Italy/            #   Nav: "Italy" (child)
+├── 030-Minimal/              # Nav: "Minimal"
+└── wip-drafts/               # NOT in nav (unnumbered)
+```
+
+This produces the navigation:
+
+```text
+Landscapes
+Travel
+  Japan
+  Italy
+Minimal
+```
+
+Unnumbered directories are excluded from the navigation tree entirely. Their albums are still generated and accessible by URL, but no navigation link points to them.
+
+If an unnumbered directory is a group, its children are promoted -- they appear at the parent level rather than being hidden:
+
+```text
+content/
+├── some-extra/               # Unnumbered group
+│   ├── 010-Alpha/            # Promoted to root level in nav
+│   └── 020-Beta/             # Promoted to root level in nav
+```

--- a/docs/src/content/directory-structure.md
+++ b/docs/src/content/directory-structure.md
@@ -1,0 +1,112 @@
+# Directory Structure
+
+Simple Gal uses the filesystem as its data source. Directories become albums, images become photos, and the hierarchy you create on disk maps directly to the navigation and URL structure of the generated site.
+
+## The content root
+
+By default, Simple Gal looks for a `content/` directory. You can change this with the `--source` flag:
+
+```bash
+simple-gal build --source my-photos --output dist
+```
+
+Everything inside this root directory is scanned and processed.
+
+## Full directory tree
+
+Here is a complete example showing all content types:
+
+```text
+content/
+├── config.toml                      # Site-wide configuration (optional)
+├── site.md                          # Site description for the home page (optional)
+├── 040-about.md                     # Page (numbered = in nav)
+├── 050-github.md                    # Link page (URL-only content)
+├── 010-Landscapes/                  # Album (contains images)
+│   ├── config.toml                  # Per-album config override (optional)
+│   ├── description.txt              # Album description (optional)
+│   ├── 001-dawn.jpg                 # Image (lowest number = preview)
+│   ├── 001-dawn.txt                 # Sidecar description for dawn.jpg
+│   ├── 002-dusk.jpg
+│   └── 010-night.jpg
+├── 020-Travel/                      # Group (contains subdirectories, not images)
+│   ├── config.toml                  # Group-level config (optional, cascades down)
+│   ├── 010-Japan/                   # Nested album
+│   │   ├── description.md           # Markdown description (takes priority over .txt)
+│   │   ├── description.txt          # Plain text description (fallback)
+│   │   ├── 001-tokyo.jpg
+│   │   ├── 001-tokyo.txt            # Sidecar description
+│   │   └── 002-kyoto.jpg
+│   └── 020-Italy/
+│       └── 001-rome.jpg
+├── 030-Minimal/                     # Another album
+│   └── 001-solo.jpg
+└── wip-drafts/                      # No number prefix = hidden from nav
+    └── 001-test.jpg
+```
+
+## How directories are classified
+
+A directory becomes one of two things, determined by what it contains:
+
+| Contains | Type | Behavior |
+|----------|------|----------|
+| Image files | **Album** | Generates a gallery page with thumbnails and individual photo pages |
+| Subdirectories | **Group** | Generates a gallery-list page showing thumbnail cards for each child album or sub-group; appears as a clickable parent entry in navigation |
+
+A directory cannot contain both images and subdirectories. This is enforced by the scanner and will produce an error:
+
+```text
+Error: Directory contains both images and subdirectories: content/010-Mixed
+```
+
+## Supported image formats
+
+Simple Gal recognizes these file extensions (case-insensitive):
+
+- `.jpg`, `.jpeg`
+- `.png`
+- `.tif`, `.tiff`
+- `.webp`
+
+All other files in album directories are ignored during scanning (except for special files like `description.md`, `config.toml`, and sidecar `.txt` files).
+
+## URL structure
+
+The generated site mirrors the directory hierarchy with number prefixes stripped:
+
+| Filesystem path | URL | Page type |
+|-----------------|-----|-----------|
+| `010-Landscapes/` | `/Landscapes/` | Album (thumbnail grid) |
+| `020-Travel/` | `/Travel/` | Gallery list (child album cards) |
+| `020-Travel/010-Japan/` | `/Travel/Japan/` | Album (thumbnail grid) |
+| `wip-drafts/` | `/wip-drafts/` | Album (thumbnail grid, hidden from nav) |
+
+Number prefixes control ordering and navigation visibility, but they are removed from the output paths and URLs.
+
+## Special files
+
+These files are recognized at the content root:
+
+| File | Purpose |
+|------|---------|
+| `config.toml` | Site configuration |
+| `site.md` or `site.txt` | Site description rendered on the home page |
+| `NNN-name.md` | Pages (appear in navigation if numbered) |
+
+These files are recognized inside album and group directories:
+
+| File | Purpose |
+|------|---------|
+| `config.toml` | Per-album/group configuration override |
+| `description.md` or `description.txt` | Description shown above the thumbnail grid (albums) or gallery list (groups) |
+| `NNN-name.txt` | Sidecar description for the image with the same stem (albums only) |
+
+## Files and directories that are ignored
+
+The scanner skips:
+
+- Hidden files and directories (names starting with `.`)
+- `processed/` and `dist/` directories (build artifacts)
+- `manifest.json`
+- The configured assets directory (default: `assets/`)

--- a/docs/src/customization/advanced.md
+++ b/docs/src/customization/advanced.md
@@ -12,7 +12,7 @@ Simple Gal generates CSS custom properties from your `config.toml` values and in
 |----------|---------|----------|
 | `--color-bg` | `#ffffff` | Page background |
 | `--color-text` | `#1a1a1a` | Primary text |
-| `--color-text-muted` | `#6b6b6b` | Secondary text (captions, descriptions, nav groups) |
+| `--color-text-muted` | `#6b6b6b` | Secondary text (captions, descriptions) |
 | `--color-border` | `#e0e0e0` | Borders, image placeholder background |
 | `--color-link` | `#1a1a1a` | Link text |
 | `--color-link-hover` | `#4a4a4a` | Link hover state |
@@ -61,15 +61,17 @@ These are the main classes in the generated HTML. Target them in `custom.css` fo
 | `.site-nav` | `<nav>` | Navigation container (hamburger menu) |
 | `.nav-panel` | `<div>` | Slide-in navigation panel |
 
-### Index Page
+### Index and Gallery-List Pages
+
+The index page and group gallery-list pages (e.g. `/Travel/`) share the same HTML structure and CSS classes.
 
 | Class | Element | Description |
 |-------|---------|-------------|
-| `.index-page` | `<main>` | Index page main container |
-| `.index-header` | `<div>` | Site title and description block |
-| `.album-grid` | `<div>` | Grid of album cards |
-| `.album-card` | `<a>` | Individual album link with thumbnail and title |
-| `.album-title` | `<span>` | Album title text below thumbnail |
+| `.index-page` | `<main>` | Page main container (used on both index and gallery-list pages) |
+| `.index-header` | `<div>` | Title and description block |
+| `.album-grid` | `<div>` | Grid of album/group cards |
+| `.album-card` | `<a>` | Individual card with thumbnail and title |
+| `.album-title` | `<span>` | Title text below thumbnail |
 
 ### Album Page
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -5,7 +5,8 @@
 //!
 //! ## Generated Pages
 //!
-//! - **Index page** (`/index.html`): Album grid showing thumbnails of all albums
+//! - **Index page** (`/index.html`): Gallery list showing top-level album/group cards
+//! - **Gallery-list pages** (`/{group}/index.html`): Gallery list for a container directory, showing cards for each child album or sub-group
 //! - **Album pages** (`/{album}/index.html`): Thumbnail grid for an album
 //! - **Image pages** (`/{album}/{n}-{slug}.html`): Full-screen image viewer with navigation
 //! - **Content pages** (`/{slug}.html`): Markdown pages (e.g. about, contact)
@@ -22,16 +23,21 @@
 //!
 //! ```text
 //! dist/
-//! ├── index.html                 # Home/gallery page
+//! ├── index.html                 # Gallery list (top-level cards)
 //! ├── about.html                 # Content page (from 040-about.md)
 //! ├── Landscapes/
-//! │   ├── index.html             # Album page
+//! │   ├── index.html             # Album page (thumbnail grid)
 //! │   ├── 1-dawn.html            # Image viewer pages
 //! │   ├── 2-sunset.html
 //! │   ├── 001-dawn-800.avif      # Processed images (copied)
 //! │   └── ...
 //! └── Travel/
-//!     └── ...
+//!     ├── index.html             # Gallery-list page (child album cards)
+//!     ├── Japan/
+//!     │   ├── index.html         # Album page
+//!     │   └── ...
+//!     └── Italy/
+//!         └── ...
 //! ```
 //!
 //! ## CSS and JavaScript

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -133,6 +133,73 @@ const FAVICON_PNG: &[u8] = include_bytes!("../static/favicon.png");
 
 const IMAGE_SIZES: &str = "(max-width: 800px) 100vw, 80vw";
 
+/// An entry in a gallery-list page (index or container page).
+struct GalleryEntry {
+    title: String,
+    path: String,
+    thumbnail: Option<String>,
+}
+
+/// Find a thumbnail for a nav item by walking into its first child recursively.
+fn find_nav_thumbnail(item: &NavItem, albums: &[Album]) -> Option<String> {
+    if item.children.is_empty() {
+        // Leaf: find the matching album
+        albums
+            .iter()
+            .find(|a| a.path == item.path)
+            .map(|a| a.thumbnail.clone())
+    } else {
+        // Container: recurse into first child
+        item.children
+            .first()
+            .and_then(|c| find_nav_thumbnail(c, albums))
+    }
+}
+
+/// Build gallery entries from nav children for a gallery-list page.
+fn collect_gallery_entries(children: &[NavItem], albums: &[Album]) -> Vec<GalleryEntry> {
+    children
+        .iter()
+        .map(|item| GalleryEntry {
+            title: item.title.clone(),
+            path: item.path.clone(),
+            thumbnail: find_nav_thumbnail(item, albums),
+        })
+        .collect()
+}
+
+/// Walk the navigation tree and find breadcrumb segments for a given path.
+///
+/// Returns a list of (title, path) pairs from root to the matching node (exclusive).
+fn path_to_breadcrumb_segments<'a>(
+    path: &str,
+    navigation: &'a [NavItem],
+) -> Vec<(&'a str, &'a str)> {
+    fn find_segments<'a>(
+        path: &str,
+        items: &'a [NavItem],
+        segments: &mut Vec<(&'a str, &'a str)>,
+    ) -> bool {
+        for item in items {
+            if item.path == path {
+                return true;
+            }
+            if path.starts_with(&format!("{}/", item.path)) {
+                segments.push((&item.title, &item.path));
+                if find_segments(path, &item.children, segments) {
+                    return true;
+                }
+                segments.pop();
+            }
+        }
+        false
+    }
+
+    let mut segments = Vec::new();
+    find_segments(path, navigation, &mut segments);
+    segments
+}
+
 /// User-provided snippets discovered via convention files in the assets directory.
 ///
 /// Drop any of these files into your `assets/` directory to inject custom content:
@@ -353,6 +420,20 @@ pub fn generate(
         let filename = format!("{}.html", page.slug);
         fs::write(output_dir.join(&filename), page_html.into_string())?;
     }
+
+    // Generate gallery-list pages for container directories
+    generate_gallery_list_pages(
+        &manifest.navigation,
+        &manifest.albums,
+        &manifest.navigation,
+        &manifest.pages,
+        &css,
+        font_url.as_deref(),
+        &manifest.config.site_title,
+        favicon_href.as_deref(),
+        &snippets,
+        output_dir,
+    )?;
 
     // Generate album pages
     for album in &manifest.albums {
@@ -584,7 +665,7 @@ fn render_nav_item(item: &NavItem, current_path: &str) -> Markup {
             @if item.children.is_empty() {
                 a href={ "/" (item.path) "/" } { (item.title) }
             } @else {
-                span.nav-group { (item.title) }
+                a.nav-group href={ "/" (item.path) "/" } { (item.title) }
                 ul {
                     @for child in &item.children {
                         (render_nav_item(child, current_path))
@@ -599,7 +680,10 @@ fn render_nav_item(item: &NavItem, current_path: &str) -> Markup {
 // Page Renderers
 // ============================================================================
 
-/// Renders the index/home page with album grid
+/// Renders the index/home page with album grid.
+///
+/// Delegates to `render_gallery_list_page` — the index is just a gallery-list
+/// of top-level navigation entries.
 fn render_index(
     manifest: &Manifest,
     css: &str,
@@ -607,50 +691,18 @@ fn render_index(
     favicon_href: Option<&str>,
     snippets: &CustomSnippets,
 ) -> Markup {
-    let nav = render_nav(&manifest.navigation, "", &manifest.pages);
-
-    let breadcrumb = html! {
-        a href="/" { (&manifest.config.site_title) }
-    };
-
-    let main_class = match manifest.description {
-        Some(_) => "index-page has-description",
-        None => "index-page",
-    };
-    let content = html! {
-        (site_header(breadcrumb, nav))
-        main class=(main_class) {
-            @if let Some(desc) = &manifest.description {
-                header.index-header {
-                    h1 { (&manifest.config.site_title) }
-                    input.desc-toggle type="checkbox" id="desc-toggle";
-                    div.album-description { (PreEscaped(desc)) }
-                    label.desc-expand for="desc-toggle" {
-                        span.expand-more { "Read more" }
-                        span.expand-less { "Show less" }
-                    }
-                }
-            }
-            div.album-grid {
-                @for album in manifest.albums.iter().filter(|a| a.in_nav) {
-                    a.album-card href={ (album.path) "/" } {
-                        img src=(album.thumbnail) alt=(album.title) loading="lazy";
-                        span.album-title { (album.title) }
-                    }
-                }
-            }
-        }
-    };
-
-    base_document(
+    render_gallery_list_page(
         &manifest.config.site_title,
+        "",
+        &collect_gallery_entries(&manifest.navigation, &manifest.albums),
+        manifest.description.as_deref(),
+        &manifest.navigation,
+        &manifest.pages,
         css,
         font_url,
-        None,
-        None,
+        &manifest.config.site_title,
         favicon_href,
         snippets,
-        content,
     )
 }
 
@@ -668,15 +720,23 @@ fn render_album_page(
 ) -> Markup {
     let nav = render_nav(navigation, &album.path, pages);
 
+    let segments = path_to_breadcrumb_segments(&album.path, navigation);
     let breadcrumb = html! {
         a href="/" { (site_title) }
+        @for (seg_title, seg_path) in &segments {
+            " › "
+            a href={ "/" (seg_path) "/" } { (seg_title) }
+        }
         " › "
         (album.title)
     };
 
-    // Strip album path prefix since album page is inside the album directory
+    // Strip album directory name prefix since album page is inside the album directory.
+    // Process-stage paths are relative to the parent dir (e.g. "Night/03-thumb.avif"
+    // for album "NY/Night"), so strip the last segment, not the full nested path.
+    let album_dir_name = album.path.rsplit('/').next().unwrap_or(&album.path);
     let strip_prefix = |path: &str| -> String {
-        path.strip_prefix(&album.path)
+        path.strip_prefix(album_dir_name)
             .and_then(|p| p.strip_prefix('/'))
             .unwrap_or(path)
             .to_string()
@@ -756,10 +816,12 @@ fn render_image_page(
 ) -> Markup {
     let nav = render_nav(navigation, &album.path, pages);
 
-    // Strip album path prefix and add ../ since image pages are in subdirectories
+    // Strip album directory name and add ../ since image pages are in subdirectories.
+    // Process-stage paths are relative to the parent dir, so strip the last segment.
+    let album_dir_name = album.path.rsplit('/').next().unwrap_or(&album.path);
     let strip_prefix = |path: &str| -> String {
         let relative = path
-            .strip_prefix(&album.path)
+            .strip_prefix(album_dir_name)
             .and_then(|p| p.strip_prefix('/'))
             .unwrap_or(path);
         format!("../{}", relative)
@@ -828,8 +890,13 @@ fn render_image_page(
     let image_label = format_image_label(display_idx, album.images.len(), image.title.as_deref());
     let page_title = format!("{} - {}", album.title, image_label);
 
+    let segments = path_to_breadcrumb_segments(&album.path, navigation);
     let breadcrumb = html! {
         a href="/" { (site_title) }
+        @for (seg_title, seg_path) in &segments {
+            " › "
+            a href={ "/" (seg_path) "/" } { (seg_title) }
+        }
         " › "
         a href="../" { (album.title) }
         " › "
@@ -968,6 +1035,135 @@ fn render_page(
     )
 }
 
+/// Renders a gallery-list page for a container directory (e.g. /NY/).
+///
+/// Structurally identical to the index page but parameterized: shows a grid
+/// of album cards for the container's children.
+#[allow(clippy::too_many_arguments)]
+fn render_gallery_list_page(
+    title: &str,
+    path: &str,
+    entries: &[GalleryEntry],
+    description: Option<&str>,
+    navigation: &[NavItem],
+    pages: &[Page],
+    css: &str,
+    font_url: Option<&str>,
+    site_title: &str,
+    favicon_href: Option<&str>,
+    snippets: &CustomSnippets,
+) -> Markup {
+    let nav = render_nav(navigation, path, pages);
+
+    let is_root = path.is_empty();
+    let segments = path_to_breadcrumb_segments(path, navigation);
+    let breadcrumb = html! {
+        a href="/" { (site_title) }
+        @if !is_root {
+            @for (seg_title, seg_path) in &segments {
+                " › "
+                a href={ "/" (seg_path) "/" } { (seg_title) }
+            }
+            " › "
+            (title)
+        }
+    };
+
+    let main_class = match description {
+        Some(_) => "index-page has-description",
+        None => "index-page",
+    };
+    let content = html! {
+        (site_header(breadcrumb, nav))
+        main class=(main_class) {
+            @if let Some(desc) = description {
+                header.index-header {
+                    h1 { (title) }
+                    input.desc-toggle type="checkbox" id="desc-toggle";
+                    div.album-description { (PreEscaped(desc)) }
+                    label.desc-expand for="desc-toggle" {
+                        span.expand-more { "Read more" }
+                        span.expand-less { "Show less" }
+                    }
+                }
+            }
+            div.album-grid {
+                @for entry in entries {
+                    a.album-card href={ "/" (entry.path) "/" } {
+                        @if let Some(ref thumb) = entry.thumbnail {
+                            img src={ "/" (thumb) } alt=(entry.title) loading="lazy";
+                        }
+                        span.album-title { (entry.title) }
+                    }
+                }
+            }
+        }
+    };
+
+    base_document(
+        title,
+        css,
+        font_url,
+        None,
+        None,
+        favicon_href,
+        snippets,
+        content,
+    )
+}
+
+/// Walk the navigation tree and generate gallery-list pages for every container.
+#[allow(clippy::too_many_arguments)]
+fn generate_gallery_list_pages(
+    items: &[NavItem],
+    albums: &[Album],
+    navigation: &[NavItem],
+    pages: &[Page],
+    css: &str,
+    font_url: Option<&str>,
+    site_title: &str,
+    favicon_href: Option<&str>,
+    snippets: &CustomSnippets,
+    output_dir: &Path,
+) -> Result<(), GenerateError> {
+    for item in items {
+        if !item.children.is_empty() {
+            let entries = collect_gallery_entries(&item.children, albums);
+            let page_html = render_gallery_list_page(
+                &item.title,
+                &item.path,
+                &entries,
+                item.description.as_deref(),
+                navigation,
+                pages,
+                css,
+                font_url,
+                site_title,
+                favicon_href,
+                snippets,
+            );
+            let dir = output_dir.join(&item.path);
+            fs::create_dir_all(&dir)?;
+            fs::write(dir.join("index.html"), page_html.into_string())?;
+
+            // Recurse into children
+            generate_gallery_list_pages(
+                &item.children,
+                albums,
+                navigation,
+                pages,
+                css,
+                font_url,
+                site_title,
+                favicon_href,
+                snippets,
+                output_dir,
+            )?;
+        }
+    }
+    Ok(())
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -1002,6 +1198,7 @@ mod tests {
             title: "Album One".to_string(),
             path: "010-one".to_string(),
             source_dir: String::new(),
+            description: None,
             children: vec![],
         }];
         let html = render_nav(&items, "", &[]).into_string();
@@ -1042,12 +1239,14 @@ mod tests {
                 title: "First".to_string(),
                 path: "010-first".to_string(),
                 source_dir: String::new(),
+                description: None,
                 children: vec![],
             },
             NavItem {
                 title: "Second".to_string(),
                 path: "020-second".to_string(),
                 source_dir: String::new(),
+                description: None,
                 children: vec![],
             },
         ];
@@ -1069,10 +1268,12 @@ mod tests {
             title: "Parent".to_string(),
             path: "010-parent".to_string(),
             source_dir: String::new(),
+            description: None,
             children: vec![NavItem {
                 title: "Child".to_string(),
                 path: "010-parent/010-child".to_string(),
                 source_dir: String::new(),
+                description: None,
                 children: vec![],
             }],
         }];
@@ -1210,6 +1411,90 @@ mod tests {
             config: SiteConfig::default(),
             support_files: vec![],
         }
+    }
+
+    /// A nested album (e.g. NY/Night) with process-stage path conventions.
+    ///
+    /// The process stage outputs image paths relative to the album's parent
+    /// directory, NOT the full nested path. So for album "NY/Night", thumbnail
+    /// paths are "Night/..." not "NY/Night/...".
+    fn create_nested_test_album() -> Album {
+        Album {
+            path: "NY/Night".to_string(),
+            title: "Night".to_string(),
+            description: None,
+            thumbnail: "Night/001-image-thumb.avif".to_string(),
+            images: vec![Image {
+                number: 1,
+                source_path: "NY/Night/001-city.jpg".to_string(),
+                title: Some("City".to_string()),
+                description: None,
+                dimensions: (1600, 1200),
+                generated: {
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "800".to_string(),
+                        GeneratedVariant {
+                            avif: "Night/001-city-800.avif".to_string(),
+                            width: 800,
+                            height: 600,
+                        },
+                    );
+                    map.insert(
+                        "1400".to_string(),
+                        GeneratedVariant {
+                            avif: "Night/001-city-1400.avif".to_string(),
+                            width: 1400,
+                            height: 1050,
+                        },
+                    );
+                    map
+                },
+                thumbnail: "Night/001-city-thumb.avif".to_string(),
+            }],
+            in_nav: true,
+            config: SiteConfig::default(),
+            support_files: vec![],
+        }
+    }
+
+    #[test]
+    fn nested_album_thumbnail_paths_are_relative_to_album_dir() {
+        let album = create_nested_test_album();
+        let html = render_album_page(&album, &[], &[], "", None, "Gallery", None, &no_snippets())
+            .into_string();
+
+        // Thumbnail src must be relative to the album directory (no parent prefix).
+        // "001-city-thumb.avif" is correct; "Night/001-city-thumb.avif" would break
+        // because the page is already served from /NY/Night/.
+        assert!(html.contains(r#"src="001-city-thumb.avif""#));
+        assert!(!html.contains("Night/001-city-thumb.avif"));
+    }
+
+    #[test]
+    fn nested_album_image_page_srcset_paths_are_relative() {
+        let album = create_nested_test_album();
+        let image = &album.images[0];
+        let html = render_image_page(
+            &album,
+            image,
+            None,
+            None,
+            &[],
+            &[],
+            "",
+            None,
+            "Gallery",
+            None,
+            &no_snippets(),
+        )
+        .into_string();
+
+        // Image page is at /NY/Night/1-City/, so srcset paths use ../ to reach
+        // the album directory. Must NOT contain the album dir name again.
+        assert!(html.contains("../001-city-800.avif"));
+        assert!(html.contains("../001-city-1400.avif"));
+        assert!(!html.contains("Night/001-city-800.avif"));
     }
 
     #[test]
@@ -1740,6 +2025,7 @@ mod tests {
             title: "<script>alert('xss')</script>".to_string(),
             path: "test".to_string(),
             source_dir: String::new(),
+            description: None,
             children: vec![],
         }];
         let html = render_nav(&items, "", &[]).into_string();
@@ -2024,7 +2310,13 @@ mod tests {
     #[test]
     fn index_page_excludes_non_nav_albums() {
         let manifest = Manifest {
-            navigation: vec![],
+            navigation: vec![NavItem {
+                title: "Visible".to_string(),
+                path: "visible".to_string(),
+                source_dir: String::new(),
+                description: None,
+                children: vec![],
+            }],
             albums: vec![
                 Album {
                     path: "visible".to_string(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -589,12 +589,14 @@ mod tests {
                 title: "A".to_string(),
                 path: "a".to_string(),
                 source_dir: "010-A".to_string(),
+                description: None,
                 children: vec![],
             },
             NavItem {
                 title: "B".to_string(),
                 path: "b".to_string(),
                 source_dir: "020-B".to_string(),
+                description: None,
                 children: vec![],
             },
         ];
@@ -614,17 +616,20 @@ mod tests {
             title: "Parent".to_string(),
             path: "parent".to_string(),
             source_dir: "010-Parent".to_string(),
+            description: None,
             children: vec![
                 NavItem {
                     title: "Child A".to_string(),
                     path: "parent/child-a".to_string(),
                     source_dir: "010-Child-A".to_string(),
+                    description: None,
                     children: vec![],
                 },
                 NavItem {
                     title: "Child B".to_string(),
                     path: "parent/child-b".to_string(),
                     source_dir: "020-Child-B".to_string(),
+                    description: None,
                     children: vec![],
                 },
             ],

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -313,6 +313,7 @@ fn scan_directory(
                 title,
                 path: album_path,
                 source_dir: source_dir_name,
+                description: None,
                 children: vec![],
             });
         }
@@ -344,10 +345,12 @@ fn scan_directory(
             let parsed = parse_entry_name(&dir_name);
             if parsed.number.is_some() {
                 let rel_path = path.strip_prefix(root).unwrap();
+                let description = read_album_description(path)?;
                 nav_items.push(NavItem {
                     title: parsed.display_title,
                     path: rel_path.to_string_lossy().to_string(),
                     source_dir: dir_name.to_string(),
+                    description,
                     children: child_nav,
                 });
             } else {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -40,7 +40,8 @@
 //! ## Output
 //!
 //! Produces a [`Manifest`] containing:
-//! - Navigation tree (numbered directories only)
+//! - Navigation tree (numbered directories only) — container directories carry an
+//!   optional `description` field read from `description.md`/`description.txt`
 //! - All albums with their images
 //! - Pages from markdown files (content pages and external links)
 //! - Site configuration

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,12 +31,18 @@ pub struct Page {
 }
 
 /// Navigation tree item (only numbered directories).
+///
+/// Leaf items (no children) correspond to albums. Items with children are
+/// container directories (groups) that generate gallery-list pages. Container
+/// items can carry an optional `description` read from `description.md`/`.txt`
+/// in the container directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NavItem {
     pub title: String,
     pub path: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub source_dir: String,
+    /// Optional description for container directories, rendered on their gallery-list page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,8 @@ pub struct NavItem {
     pub path: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub source_dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<NavItem>,
 }

--- a/static/style.css
+++ b/static/style.css
@@ -232,7 +232,7 @@ img {
 
 .site-nav .nav-group {
     display: block;
-    color: var(--color-text-muted);
+    color: var(--color-text);
     margin-bottom: 0.25rem;
 }
 


### PR DESCRIPTION
## Summary
- Container directories (e.g. `NY/`) now generate gallery-list pages with thumbnail cards for each child album/container
- Index page shows only top-level navigation entries instead of dumping all albums flat
- Navigation containers are clickable links instead of inert `<span>` labels
- Breadcrumbs reflect full nesting hierarchy (e.g. `Home › NY › Snow`)
- Fix broken image paths in nested album pages where `strip_prefix` stripped the full nested path instead of just the album directory name, causing double-nested URLs (`/NY/Night/Night/thumb.avif`)

## Test plan
- [x] All 356 tests pass (354 existing + 2 new)
- [x] New tests: `nested_album_thumbnail_paths_are_relative_to_album_dir` and `nested_album_image_page_srcset_paths_are_relative` — use realistic process-stage path conventions to catch the strip_prefix bug
- [ ] `cargo run -- build --source <content> --output <dist>` with nested content
- [ ] Verify `/index.html` shows only top-level cards
- [ ] Verify `/NY/index.html` shows sub-album cards with thumbnails and titles
- [ ] Verify `/NY/Night/` loads with working thumbnail images
- [ ] Verify breadcrumbs show `Home › NY › Snow` on nested album pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)