### PR TITLE
Fix cache race condition causing duplicate images after reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - URL slugs are now normalized: lowercased with underscores and spaces replaced by hyphens. For example, `Magna Graecia With Theo` becomes `magna-graecia-with-theo` instead of `Magna%20Graecia%20With%20Theo`. Affects album paths, image page URLs, and page slugs.
 
+### Fixed
+- Race condition in content-addressed cache: when images swap positions (e.g. reordering photos), parallel processing threads could clobber each other's cached files, causing two gallery positions to show the same image. The cache mutex now spans the entire find+copy+insert sequence, and `insert` invalidates stale content-index entries for displaced content.
+- Cache now prunes stale entries after each build: processed files for deleted/renumbered images and renamed albums are removed instead of accumulating indefinitely.
+- Nested album cache paths used only the leaf directory name (`Japan/`) instead of the full relative path (`Travel/Japan/`), causing incorrect cache lookups for nested albums.
+
 ## [0.11.1] - 2026-02-23
 
 ## [0.11.0] - 2026-02-21

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -51,7 +51,7 @@
 //! old output files are overwritten naturally.
 
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -148,6 +148,11 @@ impl CacheManifest {
     /// If an entry with the same content (source_hash + params_hash) already
     /// exists under a different output path, the old entry is removed to keep
     /// the manifest clean when images move (e.g. album rename).
+    ///
+    /// If the output path already has an entry for *different* content (e.g.
+    /// image swap: file A moved to where B used to be), the old content's
+    /// `content_index` entry is removed so stale lookups don't return a file
+    /// whose content has been overwritten.
     pub fn insert(&mut self, output_path: String, source_hash: String, params_hash: String) {
         let content_key = format!("{}:{}", source_hash, params_hash);
 
@@ -158,6 +163,15 @@ impl CacheManifest {
             self.entries.remove(old_path.as_str());
         }
 
+        // If this output path previously held different content, invalidate
+        // that content's lookup entry — the file on disk no longer matches.
+        if let Some(displaced) = self.entries.get(&output_path) {
+            let displaced_key = format!("{}:{}", displaced.source_hash, displaced.params_hash);
+            if displaced_key != content_key {
+                self.content_index.remove(&displaced_key);
+            }
+        }
+
         self.content_index.insert(content_key, output_path.clone());
         self.entries.insert(
             output_path,
@@ -166,6 +180,34 @@ impl CacheManifest {
                 params_hash,
             },
         );
+    }
+
+    /// Remove all entries whose output path is not in `live_paths`, and
+    /// delete the corresponding files from `output_dir`.
+    ///
+    /// Call this after a full build to clean up processed files for images
+    /// that were deleted, renumbered, or belong to renamed/removed albums.
+    pub fn prune(&mut self, live_paths: &HashSet<String>, output_dir: &Path) -> u32 {
+        let stale: Vec<String> = self
+            .entries
+            .keys()
+            .filter(|p| !live_paths.contains(p.as_str()))
+            .cloned()
+            .collect();
+
+        let mut removed = 0u32;
+        for path in &stale {
+            if let Some(entry) = self.entries.remove(path) {
+                let content_key = format!("{}:{}", entry.source_hash, entry.params_hash);
+                self.content_index.remove(&content_key);
+            }
+            let file = output_dir.join(path);
+            if file.exists() {
+                let _ = std::fs::remove_file(&file);
+            }
+            removed += 1;
+        }
+        removed
     }
 }
 
@@ -385,6 +427,60 @@ mod tests {
 
         assert!(!m.entries.contains_key("old-album/img-800.avif"));
         assert!(m.entries.contains_key("new-album/img-800.avif"));
+    }
+
+    #[test]
+    fn insert_invalidates_displaced_content_index() {
+        let mut m = CacheManifest::empty();
+        // Path "album/309-800.avif" holds content A
+        m.insert(
+            "album/309-800.avif".into(),
+            "hash_A".into(),
+            "params".into(),
+        );
+        assert_eq!(
+            m.content_index.get("hash_A:params"),
+            Some(&"album/309-800.avif".to_string())
+        );
+
+        // Now content B overwrites that path (image swap)
+        m.insert(
+            "album/309-800.avif".into(),
+            "hash_B".into(),
+            "params".into(),
+        );
+
+        // hash_A's content_index entry should be gone (file overwritten)
+        assert_eq!(m.content_index.get("hash_A:params"), None);
+        // hash_B points to the path
+        assert_eq!(
+            m.content_index.get("hash_B:params"),
+            Some(&"album/309-800.avif".to_string())
+        );
+    }
+
+    #[test]
+    fn prune_removes_stale_entries_and_files() {
+        let tmp = TempDir::new().unwrap();
+        let mut m = CacheManifest::empty();
+        m.insert("album/live.avif".into(), "s1".into(), "p1".into());
+        m.insert("album/stale.avif".into(), "s2".into(), "p2".into());
+
+        // Create both files on disk
+        let dir = tmp.path().join("album");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("live.avif"), "data").unwrap();
+        fs::write(dir.join("stale.avif"), "data").unwrap();
+
+        let mut live = HashSet::new();
+        live.insert("album/live.avif".to_string());
+        let removed = m.prune(&live, tmp.path());
+
+        assert_eq!(removed, 1);
+        assert!(m.entries.contains_key("album/live.avif"));
+        assert!(!m.entries.contains_key("album/stale.avif"));
+        assert!(dir.join("live.avif").exists());
+        assert!(!dir.join("stale.avif").exists());
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -339,6 +339,9 @@ pub fn format_process_event(event: &crate::process::ProcessEvent) -> Vec<String>
             }
             lines
         }
+        ProcessEvent::CachePruned { removed } => {
+            vec![format!("    Pruned {} stale cache entries", removed)]
+        }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -236,6 +236,8 @@ pub enum ProcessEvent {
         /// Per-variant cache/encode status.
         variants: Vec<VariantInfo>,
     },
+    /// Stale cache entries were pruned after processing.
+    CachePruned { removed: u32 },
 }
 
 pub fn process(
@@ -463,8 +465,30 @@ pub fn process_with_backend(
         });
     }
 
+    // Collect all output paths that are live in this build
+    let live_paths: std::collections::HashSet<String> = output_albums
+        .iter()
+        .flat_map(|album| {
+            let image_paths = album.images.iter().flat_map(|img| {
+                let mut paths: Vec<String> =
+                    img.generated.values().map(|v| v.avif.clone()).collect();
+                paths.push(img.thumbnail.clone());
+                paths
+            });
+            std::iter::once(album.thumbnail.clone()).chain(image_paths)
+        })
+        .collect();
+
+    let mut final_cache = cache.into_inner().unwrap();
+    let pruned = final_cache.prune(&live_paths, output_dir);
     let final_stats = stats.into_inner().unwrap();
-    cache.into_inner().unwrap().save(output_dir)?;
+    final_cache.save(output_dir)?;
+
+    if let Some(ref tx) = progress
+        && pruned > 0
+    {
+        tx.send(ProcessEvent::CachePruned { removed: pruned }).ok();
+    }
 
     Ok(ProcessResult {
         manifest: OutputManifest {
@@ -502,17 +526,18 @@ enum CacheLookup {
 /// `Copied` when a file with matching content was found elsewhere and
 /// copied to `expected_path`, or `Miss` when no cached version exists
 /// (or the copy failed).
+///
+/// The cache mutex is held across the entire find+copy+insert sequence to
+/// prevent a race where two threads processing swapped images clobber each
+/// other's source files (Thread A copies over B's file before B reads it).
 fn check_cache_and_copy(
     expected_path: &str,
     source_hash: &str,
     params_hash: &str,
     ctx: &CacheContext<'_>,
 ) -> CacheLookup {
-    let cached_path =
-        ctx.cache
-            .lock()
-            .unwrap()
-            .find_cached(source_hash, params_hash, ctx.cache_root);
+    let mut cache = ctx.cache.lock().unwrap();
+    let cached_path = cache.find_cached(source_hash, params_hash, ctx.cache_root);
 
     match cached_path {
         Some(ref stored) if stored == expected_path => CacheLookup::ExactHit,
@@ -524,7 +549,7 @@ fn check_cache_and_copy(
             }
             match std::fs::copy(&old_file, &new_file) {
                 Ok(_) => {
-                    ctx.cache.lock().unwrap().insert(
+                    cache.insert(
                         expected_path.to_string(),
                         source_hash.to_string(),
                         params_hash.to_string(),
@@ -565,9 +590,10 @@ fn create_responsive_images_cached(
     let mut statuses = Vec::new();
 
     let relative_dir = output_dir
-        .file_name()
-        .map(|s| s.to_str().unwrap())
-        .unwrap_or("");
+        .strip_prefix(ctx.cache_root)
+        .unwrap()
+        .to_str()
+        .unwrap();
 
     for size in sizes {
         let avif_name = format!("{}-{}.avif", filename_stem, size.target);
@@ -623,9 +649,10 @@ fn create_thumbnail_cached(
 ) -> Result<(String, VariantStatus), ProcessError> {
     let thumb_name = format!("{}-thumb.avif", filename_stem);
     let relative_dir = output_dir
-        .file_name()
-        .map(|s| s.to_str().unwrap())
-        .unwrap_or("");
+        .strip_prefix(ctx.cache_root)
+        .unwrap()
+        .to_str()
+        .unwrap();
     let relative_path = format!("{}/{}", relative_dir, thumb_name);
 
     let sharpening_tuple = config.sharpening.map(|s| (s.sigma, s.threshold));


### PR DESCRIPTION
## Summary
- **Race condition fix**: The cache mutex now spans the entire find+copy+insert sequence in `check_cache_and_copy`. Previously, the lock was released between finding a cached file and copying it, allowing parallel threads to clobber each other when images swap positions (e.g. reordering photos 309↔310 caused both to show the same image).
- **Content-index invalidation**: `cache.insert` now removes stale content-index entries when content moves to a new output path, and invalidates the displaced entry when a different content overwrites an existing path.
- **Cache pruning**: After each build, stale cache entries (deleted/renumbered images, renamed albums) are removed from both the manifest and disk, preventing indefinite cache growth.
- **Nested album paths**: `relative_dir` now uses `strip_prefix(cache_root)` instead of `file_name()`, fixing incorrect cache lookups for nested albums (e.g. `Travel/Japan/` was looked up as just `Japan/`).

## Test plan
- [x] All 360 existing tests pass
- [x] New unit test `insert_invalidates_displaced_content_index` verifies content-index cleanup
- [x] New unit test `prune_removes_stale_entries_and_files` verifies stale entry and file removal
- [ ] Manual test: reorder images in a gallery, rebuild — verify no duplicate images appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)