### PR TITLE
Add ArrowUp/Escape for up-level nav and vim j/k keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Arrow Up and Escape keys navigate up one level: from a photo to its album, from an album to its parent container, no-op on the home page
+- Vim-style `j`/`k` keys for next/previous image navigation (alongside existing `l`/`h` and arrow keys)
+- Keyboard navigation (up-level, vim keys) now works on all page types, not just image pages
+
 ## [0.11.6] - 2026-03-25
 
 ### Fixed

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -614,6 +614,7 @@ fn base_document(
             }
             body class=[body_class] {
                 (content)
+                script { (PreEscaped(JS)) }
                 @if let Some(ref html) = snippets.body_end_html {
                     (PreEscaped(html))
                 }
@@ -1013,7 +1014,6 @@ fn render_image_page(
             a.nav-prev href=(prev_url) aria-label="Previous image" {}
             a.nav-next href=(next_url) aria-label="Next image" {}
         }
-        script { (PreEscaped(JS)) }
     };
 
     base_document(

--- a/static/nav.js
+++ b/static/nav.js
@@ -2,14 +2,19 @@
 (function() {
     var prev = document.querySelector('.nav-prev');
     var next = document.querySelector('.nav-next');
-    if (!prev && !next) return;
     var prevUrl = prev && prev.getAttribute('href');
     var nextUrl = next && next.getAttribute('href');
+
+    // Parent URL: last <a> in the breadcrumb trail (the level above this page).
+    // On the home page the only link is the home link itself — no parent to go to.
+    var crumbs = document.querySelectorAll('.breadcrumb a');
+    var lastCrumb = crumbs.length > 1 ? crumbs[crumbs.length - 1] : null;
+    var parentUrl = lastCrumb ? lastCrumb.getAttribute('href') : null;
 
     // Position click zones so they overlap ~20% of the image on each side
     // and extend outward to the page edges.
     var frame = document.querySelector('.image-frame');
-    if (frame) {
+    if (frame && prev && next) {
         var OVERLAP = 0.2;
         function sizeNavZones() {
             var r = frame.getBoundingClientRect();
@@ -23,27 +28,32 @@
 
     // Keyboard navigation
     document.addEventListener('keydown', function(e) {
-        if (e.key === 'ArrowLeft' || e.key === 'h') {
+        // Previous: ArrowLeft, h, k
+        if (e.key === 'ArrowLeft' || e.key === 'h' || e.key === 'k') {
             if (prevUrl) location.href = prevUrl;
-        } else if (e.key === 'ArrowRight' || e.key === 'l') {
+        // Next: ArrowRight, l, j
+        } else if (e.key === 'ArrowRight' || e.key === 'l' || e.key === 'j') {
             if (nextUrl) location.href = nextUrl;
-        } else if (e.key === 'Escape') {
-            location.href = '../';
+        // Up a level: ArrowUp, Escape
+        } else if (e.key === 'ArrowUp' || e.key === 'Escape') {
+            if (parentUrl) location.href = parentUrl;
         }
     });
 
-    // Touch/swipe navigation
-    var sx = 0, sy = 0;
-    document.addEventListener('touchstart', function(e) {
-        sx = e.touches[0].clientX;
-        sy = e.touches[0].clientY;
-    }, { passive: true });
-    document.addEventListener('touchend', function(e) {
-        if (e.target.closest('nav, a, button')) return;
-        var dx = e.changedTouches[0].clientX - sx;
-        var dy = e.changedTouches[0].clientY - sy;
-        if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
-            location.href = dx > 0 ? prevUrl : nextUrl;
-        }
-    }, { passive: true });
+    // Touch/swipe navigation (image pages only)
+    if (prev || next) {
+        var sx = 0, sy = 0;
+        document.addEventListener('touchstart', function(e) {
+            sx = e.touches[0].clientX;
+            sy = e.touches[0].clientY;
+        }, { passive: true });
+        document.addEventListener('touchend', function(e) {
+            if (e.target.closest('nav, a, button')) return;
+            var dx = e.changedTouches[0].clientX - sx;
+            var dy = e.changedTouches[0].clientY - sy;
+            if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+                location.href = dx > 0 ? prevUrl : nextUrl;
+            }
+        }, { passive: true });
+    }
 })();


### PR DESCRIPTION
## Summary
- **ArrowUp / Escape** navigate up one level: photo → album, album → parent container, no-op on home. Parent URL derived from the last breadcrumb `<a>` link.
- **j / k** added as vim-style aliases for next/previous image (alongside existing l/h and ArrowRight/ArrowLeft).
- **nav.js moved to site-wide** — keyboard shortcuts now work on album and gallery-list pages, not just image pages. Image-page-specific behavior (click zones, swipe) still only activates when `.nav-prev`/`.nav-next` elements exist.

## Key bindings

| Key | Action |
|-----|--------|
| ArrowRight, l, j | Next image |
| ArrowLeft, h, k | Previous image |
| ArrowUp, Escape | Up one level |

## Test plan
- [x] 368 unit tests pass
- [ ] On an image page: ArrowUp goes to album, j/k navigate images
- [ ] On an album page: ArrowUp goes to parent container (or home)
- [ ] On home page: ArrowUp does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)