### PR TITLE
Add --format and --save-manifest flags to scan command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `scan` command now outputs JSON to stdout by default instead of the human-readable tree — use `--format text` for the previous behavior
+- `scan` no longer saves `manifest.json` to the temp directory by default — use `--save-manifest` to opt in (defaults to `<temp-dir>/manifest.json`, or pass a custom path)
+
+### Added
+- `--format` flag on `scan` command: `json` (default) for machine-readable output, `text` for human-readable tree display
+- `--save-manifest [path]` flag on `scan` command: explicitly save the JSON manifest to disk
+
 ## [0.11.7] - 2026-03-26
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use simple_gal::{config, generate, output, process, scan};
 use std::path::PathBuf;
 
@@ -8,6 +8,29 @@ struct CacheArgs {
     /// Disable the processing cache — force re-encoding of all images
     #[arg(long)]
     no_cache: bool,
+}
+
+/// Output format for the scan command.
+#[derive(Clone, Copy, Default, ValueEnum)]
+enum OutputFormat {
+    /// Pretty-printed JSON manifest
+    #[default]
+    Json,
+    /// Human-readable tree display
+    Text,
+}
+
+/// Arguments for the scan command.
+#[derive(clap::Args, Clone)]
+struct ScanArgs {
+    /// Output format
+    #[arg(long, default_value = "json")]
+    format: OutputFormat,
+
+    /// Save the JSON manifest to a file.
+    /// When passed without a value, uses <temp-dir>/manifest.json.
+    #[arg(long, num_args = 0..=1, default_missing_value = "__default__")]
+    save_manifest: Option<PathBuf>,
 }
 
 fn version_string() -> &'static str {
@@ -82,7 +105,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Scan content directory into a manifest
-    Scan,
+    Scan(ScanArgs),
     /// Generate responsive image sizes and thumbnails
     Process(CacheArgs),
     /// Produce the final HTML site from processed images
@@ -99,13 +122,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Scan => {
+        Command::Scan(args) => {
             let manifest = scan::scan(&cli.source)?;
-            std::fs::create_dir_all(&cli.temp_dir)?;
-            let manifest_path = cli.temp_dir.join("manifest.json");
-            let json = serde_json::to_string_pretty(&manifest)?;
-            std::fs::write(&manifest_path, json)?;
-            output::print_scan_output(&manifest, &cli.source);
+
+            if let Some(path) = args.save_manifest {
+                let manifest_path = if path.as_os_str() == "__default__" {
+                    cli.temp_dir.join("manifest.json")
+                } else {
+                    path
+                };
+                if let Some(parent) = manifest_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let json = serde_json::to_string_pretty(&manifest)?;
+                std::fs::write(&manifest_path, json)?;
+            }
+
+            match args.format {
+                OutputFormat::Json => {
+                    let json = serde_json::to_string_pretty(&manifest)?;
+                    println!("{}", json);
+                }
+                OutputFormat::Text => {
+                    output::print_scan_output(&manifest, &cli.source);
+                }
+            }
         }
         Command::Process(cache_args) => {
             let scan_manifest_path = cli.temp_dir.join("manifest.json");
@@ -158,7 +199,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let manifest = scan::scan(&source)?;
             let scan_manifest_path = cli.temp_dir.join("manifest.json");
             let json = serde_json::to_string_pretty(&manifest)?;
-            std::fs::write(&scan_manifest_path, json)?;
+            std::fs::write(&scan_manifest_path, &json)?;
             output::print_scan_output(&manifest, &source);
 
             println!("==> Stage 2: Processing images");

--- a/tests/cli_scan.rs
+++ b/tests/cli_scan.rs
@@ -1,0 +1,233 @@
+//! CLI integration tests for the `scan` subcommand.
+//!
+//! Tests `--format` (json/text) and `--save-manifest` flags.
+
+use std::path::Path;
+use std::process::Command;
+
+fn simple_gal() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_simple-gal"))
+}
+
+fn fixtures_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("fixtures/content")
+        .leak()
+}
+
+// =========================================================================
+// --format (default = json)
+// =========================================================================
+
+#[test]
+fn scan_default_format_is_json() {
+    let output = simple_gal()
+        .args(["--source", fixtures_dir().to_str().unwrap(), "scan"])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success(), "exit code: {}", output.status);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("default output should be valid JSON");
+    assert!(parsed.get("navigation").is_some());
+    assert!(parsed.get("albums").is_some());
+    assert!(parsed.get("config").is_some());
+}
+
+#[test]
+fn scan_format_json_outputs_valid_manifest() {
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "scan",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let albums = parsed["albums"].as_array().unwrap();
+    assert!(!albums.is_empty(), "should discover at least one album");
+}
+
+#[test]
+fn scan_format_text_outputs_tree() {
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "scan",
+            "--format",
+            "text",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Text output starts with "Albums" and is NOT valid JSON
+    assert!(
+        stdout.contains("Albums"),
+        "text output should start with Albums section"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stdout).is_err(),
+        "text output should not be valid JSON"
+    );
+}
+
+// =========================================================================
+// --save-manifest
+// =========================================================================
+
+#[test]
+fn scan_does_not_save_manifest_by_default() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("manifest.json");
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--temp-dir",
+            tmp.path().to_str().unwrap(),
+            "scan",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+    assert!(
+        !manifest_path.exists(),
+        "manifest.json should NOT be created without --save-manifest"
+    );
+}
+
+#[test]
+fn scan_save_manifest_default_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("manifest.json");
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--temp-dir",
+            tmp.path().to_str().unwrap(),
+            "scan",
+            "--save-manifest",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+    assert!(
+        manifest_path.exists(),
+        "manifest.json should be created at temp-dir with --save-manifest (no value)"
+    );
+
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(parsed.get("albums").is_some());
+}
+
+#[test]
+fn scan_save_manifest_custom_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let custom_path = tmp.path().join("custom/output/my-manifest.json");
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "scan",
+            "--save-manifest",
+            custom_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+    assert!(
+        custom_path.exists(),
+        "manifest should be saved to the custom path"
+    );
+
+    let content = std::fs::read_to_string(&custom_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(parsed.get("albums").is_some());
+}
+
+// =========================================================================
+// --format + --save-manifest combined
+// =========================================================================
+
+#[test]
+fn scan_text_format_with_save_manifest() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("manifest.json");
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--temp-dir",
+            tmp.path().to_str().unwrap(),
+            "scan",
+            "--format",
+            "text",
+            "--save-manifest",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+
+    // stdout is text
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Albums"));
+
+    // but the file is JSON
+    assert!(manifest_path.exists());
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(parsed.get("albums").is_some());
+}
+
+#[test]
+fn scan_json_format_with_save_manifest() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("manifest.json");
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--temp-dir",
+            tmp.path().to_str().unwrap(),
+            "scan",
+            "--format",
+            "json",
+            "--save-manifest",
+        ])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(output.status.success());
+
+    // stdout is JSON
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<serde_json::Value>(&stdout).expect("stdout should be valid JSON");
+
+    // file is also JSON
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    serde_json::from_str::<serde_json::Value>(&content).expect("saved file should be valid JSON");
+}


### PR DESCRIPTION
## Summary
- `scan` now outputs JSON to stdout by default (`--format json`) instead of the human-readable tree; use `--format text` for the previous behavior
- `scan` no longer writes `manifest.json` to disk by default; use `--save-manifest` (defaults to `<temp-dir>/manifest.json`) or `--save-manifest <path>` for a custom location
- `build` command is unchanged — it continues to save the manifest internally for the process stage

## Test plan
- [x] 8 new CLI integration tests covering all flag combinations (`tests/cli_scan.rs`)
- [x] All 368 existing unit tests still pass
- [ ] Manual: `simple-gal scan --source fixtures/content` outputs valid JSON
- [ ] Manual: `simple-gal scan --source fixtures/content --format text` outputs tree
- [ ] Manual: `simple-gal scan --source fixtures/content --save-manifest` creates file at default path
- [ ] Manual: `simple-gal build --source fixtures/content` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)