### PR TITLE
Render config errors through clapfig's renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Config file errors now render through [`clapfig`](https://crates.io/crates/clapfig) instead of dumping the raw `toml::de::Error` Debug struct. Parse failures show a header, the file path, the offending line as a source snippet, and a caret pointing at the exact token — e.g. an unquoted `thumbnail_gap = 0.1rem` now points at `0.1rem` with `expected newline, \`#\`` as the label. The CLI picks clapfig's `render_rich` (miette-based, colored, Unicode box drawing) when stderr is a TTY and `render_plain` (ANSI-free, pipe-safe) otherwise. `ConfigError::Toml` now carries `path` + `source_text` alongside the underlying parser error so the renderer has everything it needs.
+
 ## [0.12.0] - 2026-04-11
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +236,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,10 +393,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "clapfig"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74d81b0df452433e29c223509993da940d6311edec605a4a9b2a099c47d2eee"
+dependencies = [
+ "confique",
+ "directories",
+ "miette",
+ "serde",
+ "serde_ignored",
+ "thiserror",
+ "toml 0.8.23",
+ "toml_edit",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "confique"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f"
+dependencies = [
+ "confique-macro",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "confique-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d1754680cd218e7bcb4c960cc9bae3444b5197d64563dccccfdf83cab9e1a7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "convert_case"
@@ -525,6 +597,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,7 +764,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -696,6 +789,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "half"
@@ -924,6 +1023,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1079,15 @@ checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1048,6 +1162,36 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1151,6 +1295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1314,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1472,6 +1637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1695,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -1620,6 +1802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1690,6 +1891,7 @@ version = "0.12.0"
 dependencies = [
  "avif-parse",
  "clap",
+ "clapfig",
  "headless_chrome",
  "image",
  "maud",
@@ -1701,7 +1903,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.8.23",
  "walkdir",
 ]
 
@@ -1763,6 +1965,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2018,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1854,9 +2097,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -1869,6 +2127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,10 +2143,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -1887,6 +2163,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tungstenite"
@@ -1924,10 +2206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2250,6 +2544,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ exclude = ["fixtures/", "tests/", "scripts/", "*.config.*", "package.json", "pac
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+# Used solely for structured error data + plain/rich (miette) renderers on
+# config file parse failures. We do not use clapfig's config loader — keeping
+# default-features off skips the clap adapter we don't need.
+clapfig = { version = "0.13", default-features = false, features = ["rich-errors"] }
 image = { version = "0.25", default-features = false, features = [
     "jpeg", "png", "tiff", "webp",
     "avif",

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,17 +100,50 @@
 
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("TOML parse error: {0}")]
-    Toml(#[from] toml::de::Error),
+    /// A TOML parse failure on a specific config file.
+    ///
+    /// Carries the originating path and the full file contents so callers
+    /// (e.g. the CLI in `main.rs`) can hand the error to clapfig's renderer
+    /// for a snippet + caret view instead of showing a bare parser message.
+    #[error("failed to parse {}: {source}", path.display())]
+    Toml {
+        path: PathBuf,
+        #[source]
+        source: Box<toml::de::Error>,
+        source_text: String,
+    },
     #[error("Config validation error: {0}")]
     Validation(String),
+}
+
+impl ConfigError {
+    /// Convert a config error into the richer `clapfig::error::ClapfigError`
+    /// representation when possible, so the CLI can render it through
+    /// clapfig's plain/rich (miette) renderers. Returns `None` for error
+    /// kinds that don't carry source-file context (IO failures, range
+    /// validation failures).
+    pub fn to_clapfig_error(&self) -> Option<clapfig::error::ClapfigError> {
+        match self {
+            ConfigError::Toml {
+                path,
+                source,
+                source_text,
+            } => Some(clapfig::error::ClapfigError::ParseError {
+                path: path.clone(),
+                source: source.clone(),
+                source_text: Some(Arc::from(source_text.as_str())),
+            }),
+            _ => None,
+        }
+    }
 }
 
 /// Site configuration loaded from `config.toml`.
@@ -824,7 +857,11 @@ pub fn load_partial_config(path: &Path) -> Result<Option<PartialSiteConfig>, Con
         return Ok(None);
     }
     let content = fs::read_to_string(&config_path)?;
-    let partial: PartialSiteConfig = toml::from_str(&content)?;
+    let partial: PartialSiteConfig = toml::from_str(&content).map_err(|e| ConfigError::Toml {
+        path: config_path.clone(),
+        source: Box::new(e),
+        source_text: content,
+    })?;
     Ok(Some(partial))
 }
 
@@ -1156,6 +1193,82 @@ quality = 85
     }
 
     #[test]
+    fn toml_error_carries_path_and_source_text() {
+        let tmp = TempDir::new().unwrap();
+        // Unquoted CSS value — the same class of mistake that produced the
+        // original "expected newline, `#`" error we want rich rendering for.
+        fs::write(
+            tmp.path().join("config.toml"),
+            "[theme]\nthumbnail_gap = 0.2rem\n",
+        )
+        .unwrap();
+        let err = load_config(tmp.path()).unwrap_err();
+        match &err {
+            ConfigError::Toml {
+                path,
+                source_text,
+                source,
+            } => {
+                assert!(path.ends_with("config.toml"));
+                assert!(source_text.contains("thumbnail_gap"));
+                assert!(source.span().is_some());
+            }
+            other => panic!("expected Toml variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn to_clapfig_error_wraps_parse_failure() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("config.toml"),
+            "[theme]\nthumbnail_gap = 0.2rem\n",
+        )
+        .unwrap();
+        let err = load_config(tmp.path()).unwrap_err();
+        let clap_err = err
+            .to_clapfig_error()
+            .expect("parse errors should be convertible to ClapfigError");
+
+        // Structural check: the data is populated — path, toml::de::Error,
+        // and the retained source text.
+        let (path, parse_err, source_text) = clap_err
+            .parse_error()
+            .expect("ClapfigError should be a ParseError");
+        assert!(path.ends_with("config.toml"));
+        assert!(parse_err.span().is_some());
+        assert!(source_text.unwrap().contains("thumbnail_gap"));
+    }
+
+    #[test]
+    fn to_clapfig_error_is_none_for_validation_failure() {
+        let err = ConfigError::Validation("quality out of range".into());
+        assert!(err.to_clapfig_error().is_none());
+    }
+
+    #[test]
+    fn clapfig_render_plain_includes_path_and_snippet() {
+        // End-to-end check that we can hand the error to clapfig's plain
+        // renderer and get back a snippet that points at the bad line.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("config.toml"),
+            "[theme]\nthumbnail_gap = 0.2rem\n",
+        )
+        .unwrap();
+        let err = load_config(tmp.path()).unwrap_err();
+        let clap_err = err.to_clapfig_error().unwrap();
+        let out = clapfig::render::render_plain(&clap_err);
+
+        assert!(out.contains("config.toml"), "missing path in {out}");
+        assert!(
+            out.contains("thumbnail_gap"),
+            "missing source snippet in {out}"
+        );
+        assert!(out.contains('^'), "missing caret in {out}");
+    }
+
+    #[test]
     fn default_full_index_is_off() {
         let config = SiteConfig::default();
         assert!(!config.full_index.generates);
@@ -1302,7 +1415,7 @@ link_hover = "#f88"
         fs::write(&config_path, "this is not valid toml [[[").unwrap();
 
         let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Toml(_))));
+        assert!(matches!(result, Err(ConfigError::Toml { .. })));
     }
 
     #[test]
@@ -1320,7 +1433,7 @@ link_hover = "#f88"
         .unwrap();
 
         let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Toml(_))));
+        assert!(matches!(result, Err(ConfigError::Toml { .. })));
     }
 
     // =========================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use simple_gal::{config, generate, output, process, scan};
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 /// Shared flags for commands that process images.
@@ -118,7 +119,55 @@ enum Command {
     GenConfig,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
+    if let Err(err) = run() {
+        report_error(err.as_ref());
+        std::process::exit(1);
+    }
+}
+
+/// Walk the error `source()` chain looking for a [`config::ConfigError`].
+/// Returns the matching error if one is found so the CLI can render it
+/// through clapfig's plain/rich renderers; returns `None` for every other
+/// error kind (IO, process, generate, …).
+fn find_config_error<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a config::ConfigError> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(cfg) = e.downcast_ref::<config::ConfigError>() {
+            return Some(cfg);
+        }
+        current = e.source();
+    }
+    None
+}
+
+/// Print an error to stderr with the best renderer available for the
+/// current environment. Config parse failures get clapfig's rich/plain
+/// treatment (source snippet + caret); everything else falls through to a
+/// plain `Error: {message}` line.
+fn report_error(err: &(dyn std::error::Error + 'static)) {
+    if let Some(cfg_err) = find_config_error(err)
+        && let Some(clap_err) = cfg_err.to_clapfig_error()
+    {
+        let msg = if std::io::stderr().is_terminal() {
+            clapfig::render::render_rich(&clap_err)
+        } else {
+            clapfig::render::render_plain(&clap_err)
+        };
+        eprintln!("{msg}");
+        return;
+    }
+    eprintln!("Error: {err}");
+    let mut source = err.source();
+    while let Some(cause) = source {
+        eprintln!("  caused by: {cause}");
+        source = cause.source();
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {

--- a/tests/cli_config_errors.rs
+++ b/tests/cli_config_errors.rs
@@ -1,0 +1,86 @@
+//! End-to-end check that a bad `config.toml` produces a clapfig-rendered
+//! error (source snippet + caret) instead of the old Debug dump.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn simple_gal() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_simple-gal"))
+}
+
+fn write_bad_config(dir: &Path) {
+    // Unquoted CSS value — the exact class of mistake the user hit in
+    // practice. TOML parses `0.1` as a float and then chokes on `rem`.
+    fs::write(
+        dir.join("config.toml"),
+        "site_title = \"Bad\"\n\n[theme]\nthumbnail_gap = 0.1rem\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn build_with_bad_config_renders_clapfig_plain_error() {
+    let tmp = TempDir::new().unwrap();
+    write_bad_config(tmp.path());
+
+    let output = simple_gal()
+        .args(["--source", tmp.path().to_str().unwrap(), "build"])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit on bad config, got: {}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // clapfig's plain renderer produces a multi-line message with the
+    // "error: failed to parse config file" header, file path, a source
+    // snippet, and caret markers. Make sure we're seeing that — not the
+    // bare Debug dump the CLI used to show.
+    assert!(
+        stderr.contains("failed to parse config file"),
+        "missing parse error header. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("config.toml"),
+        "missing file path. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("thumbnail_gap"),
+        "missing source snippet. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains('^'),
+        "missing caret marker. stderr:\n{stderr}"
+    );
+
+    // Regression: the old output exposed internal enum structure.
+    assert!(
+        !stderr.contains("Config(Toml("),
+        "stderr should not contain raw Debug output. stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn scan_with_bad_config_renders_clapfig_plain_error() {
+    // Same check for the scan command, which also touches config loading.
+    let tmp = TempDir::new().unwrap();
+    write_bad_config(tmp.path());
+
+    let output = simple_gal()
+        .args(["--source", tmp.path().to_str().unwrap(), "scan"])
+        .output()
+        .expect("failed to run simple-gal");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to parse config file"));
+    assert!(stderr.contains("config.toml"));
+    assert!(stderr.contains('^'));
+    assert!(!stderr.contains("Config(Toml("));
+}


### PR DESCRIPTION
## Summary
- Add `clapfig` 0.13 (with the `rich-errors` feature) solely to pick up its structured `ClapfigError` type and plain/rich renderers. `default-features = false` because we don't need the clap adapter — we keep our own CLI.
- `ConfigError::Toml` is now a struct variant carrying `path` + `source_text` alongside the boxed `toml::de::Error`. `ConfigError::to_clapfig_error()` converts that into a `ClapfigError::ParseError` so the CLI can hand it to a renderer.
- `main.rs` splits into `run()` + `report_error()`. `report_error` walks the error source chain for a `ConfigError`, converts it, and picks `clapfig::render::render_rich` when stderr is a TTY (miette-based, ANSI box drawing, source snippet with caret) or `render_plain` otherwise (ANSI-free, pipe- and log-safe). Other errors fall through to `Error: {e}` plus indented `caused by` lines.

## Before / after

A realistic mistake — `thumbnail_gap = 0.1rem` (should be `"0.1rem"`). Before:

```
Error: Config(Toml(TomlError { message: "expected newline, `#`", raw: Some("# Simple Gal Configuration\n# ========\n...
```

After (plain, piped to a file):

```
error: failed to parse config file
  --> /tmp/cf-bad/config.toml:4:20
   4 | thumbnail_gap = 0.1rem
                          ^

expected newline, `#`
```

And on a real TTY you get miette's colored box drawing with source snippet and an arrow pointing at the span.

## Test plan
- [x] `cargo test` — 393 tests pass (4 new config unit tests: struct variant population, `to_clapfig_error` happy path, `None` for validation errors, plain-render snippet/caret; 2 new `tests/cli_config_errors.rs` integration tests: build + scan on a bad config assert the rendered header/path/snippet/caret and that the old Debug dump is gone).
- [x] Manual end-to-end: ran `cargo run -- --source /tmp/cf-bad build` both piped (plain) and under `script` (TTY/rich) and confirmed the renderer picks the right mode and points at the bad token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)