### PR TITLE
Automation-friendly CLI: JSON envelopes, granular exit codes, --quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Machine-readable JSON output for every command, gated by a new global `--format {text,json}` flag. `scan` keeps its JSON default (from v0.12); every other command defaults to text. In JSON mode each command emits exactly one tagged envelope — `{"ok": true, "command": "<name>", "data": {...}}` — to stdout on success, so automation (GUIs, shell scripts) can parse output without scraping.
+- Structured error envelopes on stderr when a command fails in JSON mode: `{"ok": false, "kind": "<classification>", "message": "...", "causes": [...], "config": {path, line, column, snippet}?}`. Config parse failures populate the `config` field with the same snippet/line/column information clapfig shows in text mode, so a GUI can highlight the exact offending token without re-parsing the TOML.
+- Granular process exit codes that let callers branch on failure type without parsing messages: `0` success, `1` internal, `2` usage (clap), `3` config, `4` io, `5` scan, `6` process, `7` generate, `8` validation. Previously every failure exited `1`.
+- Global `--quiet` flag suppresses non-error stdout in text mode (no effect in JSON mode, which is already a single document).
+
+### Changed
+- Text-mode error rendering is unchanged (clapfig rich/plain for config errors, plain `Error:` + cause chain otherwise). JSON-mode error rendering replaces it with the structured envelope on stderr; stdout stays empty on failure so scripts can always `jq` stderr.
+- `--format` moved from a `scan`-only flag to a global flag. `simple-gal scan --format json` still works; `simple-gal --format json scan` is now the canonical form and the same flag applies to every other command.
+
 ## [0.13.0] - 2026-04-11
 
 ### Changed

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -1,0 +1,407 @@
+//! Machine-readable JSON envelopes for every CLI command + the error path.
+//!
+//! Every command, when invoked with `--format json`, emits exactly one JSON
+//! document to stdout (for success) or to stderr (for errors). These types
+//! define the on-the-wire shape of those documents and are the automation
+//! contract: GUIs and shell scripts parse them instead of scraping the
+//! human-readable text output.
+
+use crate::cache::CacheStats;
+use crate::config::ConfigError;
+use crate::generate;
+use crate::scan;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// Error envelope
+// ============================================================================
+
+/// Classification of a CLI failure. Drives both the JSON `kind` field and
+/// the process exit code so automated callers can branch on failure type
+/// without parsing messages.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorKind {
+    Config,
+    Io,
+    Scan,
+    Process,
+    Generate,
+    Validation,
+    Usage,
+    Internal,
+}
+
+impl ErrorKind {
+    /// Process exit code for this error kind. 0 is reserved for success;
+    /// 2 is reserved for clap/usage errors (clap emits those directly).
+    pub fn exit_code(self) -> i32 {
+        match self {
+            ErrorKind::Internal => 1,
+            ErrorKind::Usage => 2,
+            ErrorKind::Config => 3,
+            ErrorKind::Io => 4,
+            ErrorKind::Scan => 5,
+            ErrorKind::Process => 6,
+            ErrorKind::Generate => 7,
+            ErrorKind::Validation => 8,
+        }
+    }
+}
+
+/// Extra context for config-file parse failures so a GUI can highlight
+/// the exact token without re-parsing.
+#[derive(Debug, Serialize)]
+pub struct ConfigErrorPayload {
+    pub path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+}
+
+/// The top-level shape emitted to stderr when any command fails in JSON mode.
+#[derive(Debug, Serialize)]
+pub struct ErrorEnvelope {
+    pub ok: bool,
+    pub kind: ErrorKind,
+    pub message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub causes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<ConfigErrorPayload>,
+}
+
+impl ErrorEnvelope {
+    pub fn new(kind: ErrorKind, err: &(dyn std::error::Error + 'static)) -> Self {
+        let message = err.to_string();
+        let mut causes = Vec::new();
+        let mut src = err.source();
+        while let Some(cause) = src {
+            causes.push(cause.to_string());
+            src = cause.source();
+        }
+        let config = find_config_error(err).map(config_error_payload);
+        Self {
+            ok: false,
+            kind,
+            message,
+            causes,
+            config,
+        }
+    }
+}
+
+fn find_config_error<'a>(err: &'a (dyn std::error::Error + 'static)) -> Option<&'a ConfigError> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(cfg) = e.downcast_ref::<ConfigError>() {
+            return Some(cfg);
+        }
+        current = e.source();
+    }
+    None
+}
+
+fn config_error_payload(cfg: &ConfigError) -> ConfigErrorPayload {
+    match cfg {
+        ConfigError::Toml {
+            path,
+            source,
+            source_text,
+        } => {
+            let (line, column) = source
+                .span()
+                .map(|span| offset_to_line_col(source_text, span.start))
+                .unwrap_or((None, None));
+            let snippet = source
+                .span()
+                .and_then(|span| extract_snippet(source_text, span.start));
+            ConfigErrorPayload {
+                path: path.clone(),
+                line,
+                column,
+                snippet,
+            }
+        }
+        _ => ConfigErrorPayload {
+            path: PathBuf::new(),
+            line: None,
+            column: None,
+            snippet: None,
+        },
+    }
+}
+
+fn offset_to_line_col(text: &str, offset: usize) -> (Option<usize>, Option<usize>) {
+    let offset = offset.min(text.len());
+    let prefix = &text[..offset];
+    let line = prefix.bytes().filter(|b| *b == b'\n').count() + 1;
+    let col = prefix.rfind('\n').map(|i| offset - i - 1).unwrap_or(offset) + 1;
+    (Some(line), Some(col))
+}
+
+fn extract_snippet(text: &str, offset: usize) -> Option<String> {
+    let offset = offset.min(text.len());
+    let start = text[..offset].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let end = text[offset..]
+        .find('\n')
+        .map(|i| offset + i)
+        .unwrap_or(text.len());
+    Some(text[start..end].to_string())
+}
+
+// ============================================================================
+// Success envelopes
+// ============================================================================
+
+/// Wrapper written to stdout for every successful command in JSON mode.
+/// The `command` tag lets a GUI dispatch on the payload shape.
+#[derive(Debug, Serialize)]
+pub struct OkEnvelope<T: Serialize> {
+    pub ok: bool,
+    pub command: &'static str,
+    pub data: T,
+}
+
+impl<T: Serialize> OkEnvelope<T> {
+    pub fn new(command: &'static str, data: T) -> Self {
+        Self {
+            ok: true,
+            command,
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Counts {
+    pub albums: usize,
+    pub images: usize,
+    pub pages: usize,
+}
+
+// ----- scan -----
+
+#[derive(Debug, Serialize)]
+pub struct ScanPayload<'a> {
+    pub source: &'a Path,
+    pub counts: Counts,
+    pub manifest: &'a scan::Manifest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub saved_manifest_path: Option<PathBuf>,
+}
+
+impl<'a> ScanPayload<'a> {
+    pub fn new(
+        manifest: &'a scan::Manifest,
+        source: &'a Path,
+        saved_manifest_path: Option<PathBuf>,
+    ) -> Self {
+        let images = manifest.albums.iter().map(|a| a.images.len()).sum();
+        Self {
+            source,
+            counts: Counts {
+                albums: manifest.albums.len(),
+                images,
+                pages: manifest.pages.len(),
+            },
+            manifest,
+            saved_manifest_path,
+        }
+    }
+}
+
+// ----- process -----
+
+#[derive(Debug, Serialize)]
+pub struct CacheStatsPayload {
+    pub cached: u32,
+    pub copied: u32,
+    pub encoded: u32,
+    pub total: u32,
+}
+
+impl From<&CacheStats> for CacheStatsPayload {
+    fn from(s: &CacheStats) -> Self {
+        Self {
+            cached: s.hits,
+            copied: s.copies,
+            encoded: s.misses,
+            total: s.total(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProcessPayload {
+    pub processed_dir: PathBuf,
+    pub manifest_path: PathBuf,
+    pub cache: CacheStatsPayload,
+}
+
+// ----- generate -----
+
+#[derive(Debug, Serialize)]
+pub struct GeneratePayload<'a> {
+    pub output: &'a Path,
+    pub counts: GenerateCounts,
+    pub albums: Vec<GeneratedAlbum>,
+    pub pages: Vec<GeneratedPage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GenerateCounts {
+    pub albums: usize,
+    pub image_pages: usize,
+    pub pages: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GeneratedAlbum {
+    pub title: String,
+    pub path: String,
+    pub index_html: String,
+    pub image_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GeneratedPage {
+    pub title: String,
+    pub slug: String,
+    pub is_link: bool,
+}
+
+impl<'a> GeneratePayload<'a> {
+    pub fn new(manifest: &'a generate::Manifest, output: &'a Path) -> Self {
+        let image_pages = manifest.albums.iter().map(|a| a.images.len()).sum();
+        let pages_count = manifest.pages.iter().filter(|p| !p.is_link).count();
+        let albums = manifest
+            .albums
+            .iter()
+            .map(|a| GeneratedAlbum {
+                title: a.title.clone(),
+                path: a.path.clone(),
+                index_html: format!("{}/index.html", a.path),
+                image_count: a.images.len(),
+            })
+            .collect();
+        let pages = manifest
+            .pages
+            .iter()
+            .map(|p| GeneratedPage {
+                title: p.title.clone(),
+                slug: p.slug.clone(),
+                is_link: p.is_link,
+            })
+            .collect();
+        Self {
+            output,
+            counts: GenerateCounts {
+                albums: manifest.albums.len(),
+                image_pages,
+                pages: pages_count,
+            },
+            albums,
+            pages,
+        }
+    }
+}
+
+// ----- build -----
+
+#[derive(Debug, Serialize)]
+pub struct BuildPayload<'a> {
+    pub source: &'a Path,
+    pub output: &'a Path,
+    pub counts: GenerateCounts,
+    pub cache: CacheStatsPayload,
+}
+
+// ----- check -----
+
+#[derive(Debug, Serialize)]
+pub struct CheckPayload<'a> {
+    pub valid: bool,
+    pub source: &'a Path,
+    pub counts: Counts,
+}
+
+// ----- gen-config -----
+
+#[derive(Debug, Serialize)]
+pub struct GenConfigPayload {
+    pub toml: String,
+}
+
+// ============================================================================
+// Helpers for writing envelopes
+// ============================================================================
+
+/// Serialize `value` to pretty JSON on stdout, followed by a newline.
+pub fn emit_stdout<T: Serialize>(value: &T) {
+    match serde_json::to_string_pretty(value) {
+        Ok(s) => println!("{s}"),
+        Err(e) => eprintln!("Error: failed to serialize output: {e}"),
+    }
+}
+
+/// Serialize `value` to pretty JSON on stderr, followed by a newline. Used
+/// for error envelopes so stdout stays clean on failure.
+pub fn emit_stderr<T: Serialize>(value: &T) {
+    match serde_json::to_string_pretty(value) {
+        Ok(s) => eprintln!("{s}"),
+        Err(e) => eprintln!("Error: failed to serialize error: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_codes_are_distinct() {
+        let kinds = [
+            ErrorKind::Internal,
+            ErrorKind::Usage,
+            ErrorKind::Config,
+            ErrorKind::Io,
+            ErrorKind::Scan,
+            ErrorKind::Process,
+            ErrorKind::Generate,
+            ErrorKind::Validation,
+        ];
+        let codes: Vec<i32> = kinds.iter().map(|k| k.exit_code()).collect();
+        let mut sorted = codes.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), kinds.len(), "exit codes must be unique");
+        assert!(!codes.contains(&0), "0 is reserved for success");
+    }
+
+    #[test]
+    fn error_envelope_collects_causes() {
+        use std::io;
+        let err = io::Error::other("outer");
+        let env = ErrorEnvelope::new(ErrorKind::Io, &err);
+        assert!(!env.ok);
+        assert_eq!(env.message, "outer");
+    }
+
+    #[test]
+    fn offset_to_line_col_first_line() {
+        let (line, col) = offset_to_line_col("hello\nworld", 3);
+        assert_eq!(line, Some(1));
+        assert_eq!(col, Some(4));
+    }
+
+    #[test]
+    fn offset_to_line_col_second_line() {
+        let (line, col) = offset_to_line_col("hello\nworld", 8);
+        assert_eq!(line, Some(2));
+        assert_eq!(col, Some(3));
+    }
+}

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -84,7 +84,11 @@ impl ErrorEnvelope {
             causes.push(cause.to_string());
             src = cause.source();
         }
-        let config = find_config_error(err).map(config_error_payload);
+        // Only attach a `config` payload for parse-location-carrying
+        // variants (currently `ConfigError::Toml`). Validation/IO config
+        // errors have no file position, so we leave the field unset
+        // instead of emitting an empty `path` that would confuse clients.
+        let config = find_config_error(err).and_then(config_error_payload);
         Self {
             ok: false,
             kind,
@@ -106,7 +110,7 @@ fn find_config_error<'a>(err: &'a (dyn std::error::Error + 'static)) -> Option<&
     None
 }
 
-fn config_error_payload(cfg: &ConfigError) -> ConfigErrorPayload {
+fn config_error_payload(cfg: &ConfigError) -> Option<ConfigErrorPayload> {
     match cfg {
         ConfigError::Toml {
             path,
@@ -120,19 +124,16 @@ fn config_error_payload(cfg: &ConfigError) -> ConfigErrorPayload {
             let snippet = source
                 .span()
                 .and_then(|span| extract_snippet(source_text, span.start));
-            ConfigErrorPayload {
+            Some(ConfigErrorPayload {
                 path: path.clone(),
                 line,
                 column,
                 snippet,
-            }
+            })
         }
-        _ => ConfigErrorPayload {
-            path: PathBuf::new(),
-            line: None,
-            column: None,
-            snippet: None,
-        },
+        // Validation / IO config errors carry no file position — skip
+        // the payload entirely rather than emit an empty `path`.
+        _ => None,
     }
 }
 
@@ -342,20 +343,21 @@ pub struct GenConfigPayload {
 // ============================================================================
 
 /// Serialize `value` to pretty JSON on stdout, followed by a newline.
-pub fn emit_stdout<T: Serialize>(value: &T) {
-    match serde_json::to_string_pretty(value) {
-        Ok(s) => println!("{s}"),
-        Err(e) => eprintln!("Error: failed to serialize output: {e}"),
-    }
+/// Returns the serde error so the caller can route a serialization
+/// failure through the normal error envelope + exit-code path — we never
+/// want to print a truncated document and silently exit 0.
+pub fn emit_stdout<T: Serialize>(value: &T) -> Result<(), serde_json::Error> {
+    let s = serde_json::to_string_pretty(value)?;
+    println!("{s}");
+    Ok(())
 }
 
 /// Serialize `value` to pretty JSON on stderr, followed by a newline. Used
 /// for error envelopes so stdout stays clean on failure.
-pub fn emit_stderr<T: Serialize>(value: &T) {
-    match serde_json::to_string_pretty(value) {
-        Ok(s) => eprintln!("{s}"),
-        Err(e) => eprintln!("Error: failed to serialize error: {e}"),
-    }
+pub fn emit_stderr<T: Serialize>(value: &T) -> Result<(), serde_json::Error> {
+    let s = serde_json::to_string_pretty(value)?;
+    eprintln!("{s}");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod cache;
 pub mod config;
 pub mod generate;
 pub mod imaging;
+pub mod json_output;
 pub mod metadata;
 pub mod naming;
 pub mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use simple_gal::json_output::{
+    self, BuildPayload, CacheStatsPayload, CheckPayload, Counts, ErrorEnvelope, ErrorKind,
+    GenConfigPayload, GeneratePayload, OkEnvelope, ProcessPayload, ScanPayload,
+};
 use simple_gal::{config, generate, output, process, scan};
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Shared flags for commands that process images.
 #[derive(clap::Args, Clone)]
@@ -11,23 +15,21 @@ struct CacheArgs {
     no_cache: bool,
 }
 
-/// Output format for the scan command.
-#[derive(Clone, Copy, Default, ValueEnum)]
+/// Output format for all commands.
+///
+/// `text` is the human-readable default; `json` is the machine-readable
+/// envelope format documented in [`json_output`] and used by scripts and
+/// GUIs. In JSON mode every command emits exactly one JSON document — to
+/// stdout on success, to stderr on error — so callers can always `jq` it.
+#[derive(Clone, Copy, ValueEnum)]
 enum OutputFormat {
-    /// Pretty-printed JSON manifest
-    #[default]
-    Json,
-    /// Human-readable tree display
     Text,
+    Json,
 }
 
 /// Arguments for the scan command.
 #[derive(clap::Args, Clone)]
 struct ScanArgs {
-    /// Output format
-    #[arg(long, default_value = "json")]
-    format: OutputFormat,
-
     /// Save the JSON manifest to a file.
     /// When passed without a value, uses <temp-dir>/manifest.json.
     #[arg(long, num_args = 0..=1, default_missing_value = "__default__")]
@@ -99,6 +101,16 @@ struct Cli {
     #[arg(long, default_value = ".simple-gal-temp", global = true)]
     temp_dir: PathBuf,
 
+    /// Output format: `text` (human-readable, default for most commands)
+    /// or `json` (machine-readable envelope, one document on stdout or stderr).
+    /// The `scan` command defaults to `json` for backwards compatibility.
+    #[arg(long, global = true, value_enum)]
+    format: Option<OutputFormat>,
+
+    /// Suppress non-error output in text mode. No effect on JSON mode.
+    #[arg(long, global = true)]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -119,17 +131,84 @@ enum Command {
     GenConfig,
 }
 
+/// Wrapper around any command error tagged with an [`ErrorKind`] so the
+/// CLI can render it appropriately and pick a matching exit code.
+struct CliError {
+    kind: ErrorKind,
+    source: Box<dyn std::error::Error + 'static>,
+}
+
+impl CliError {
+    fn new(kind: ErrorKind, source: Box<dyn std::error::Error + 'static>) -> Self {
+        // If the error chain contains a ConfigError, reclassify — a config
+        // parse failure inside the scan stage is still a config error from
+        // the user's point of view.
+        let kind = if find_config_error(source.as_ref()).is_some() {
+            ErrorKind::Config
+        } else if is_io_error(source.as_ref()) {
+            // Promote raw IO errors out of Internal classification when
+            // nothing more specific is available.
+            match kind {
+                ErrorKind::Internal => ErrorKind::Io,
+                other => other,
+            }
+        } else {
+            kind
+        };
+        CliError { kind, source }
+    }
+}
+
+fn is_io_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cur {
+        if e.downcast_ref::<std::io::Error>().is_some() {
+            return true;
+        }
+        cur = e.source();
+    }
+    false
+}
+
+trait TagError<T> {
+    fn tag(self, kind: ErrorKind) -> Result<T, CliError>;
+}
+
+impl<T, E> TagError<T> for Result<T, E>
+where
+    E: Into<Box<dyn std::error::Error + 'static>>,
+{
+    fn tag(self, kind: ErrorKind) -> Result<T, CliError> {
+        self.map_err(|e| CliError::new(kind, e.into()))
+    }
+}
+
 fn main() {
-    if let Err(err) = run() {
-        report_error(err.as_ref());
-        std::process::exit(1);
+    let cli = Cli::parse();
+    let format = resolve_format(&cli);
+    match run(&cli, format) {
+        Ok(()) => {}
+        Err(err) => {
+            report_error(err.source.as_ref(), err.kind, format);
+            std::process::exit(err.kind.exit_code());
+        }
+    }
+}
+
+/// Resolve the effective output format: explicit `--format`, else the
+/// command's default. `scan` defaults to JSON (historical behavior from
+/// v0.12); everything else defaults to text.
+fn resolve_format(cli: &Cli) -> OutputFormat {
+    if let Some(fmt) = cli.format {
+        return fmt;
+    }
+    match cli.command {
+        Command::Scan(_) => OutputFormat::Json,
+        _ => OutputFormat::Text,
     }
 }
 
 /// Walk the error `source()` chain looking for a [`config::ConfigError`].
-/// Returns the matching error if one is found so the CLI can render it
-/// through clapfig's plain/rich renderers; returns `None` for every other
-/// error kind (IO, process, generate, …).
 fn find_config_error<'a>(
     err: &'a (dyn std::error::Error + 'static),
 ) -> Option<&'a config::ConfigError> {
@@ -143,11 +222,17 @@ fn find_config_error<'a>(
     None
 }
 
-/// Print an error to stderr with the best renderer available for the
-/// current environment. Config parse failures get clapfig's rich/plain
-/// treatment (source snippet + caret); everything else falls through to a
-/// plain `Error: {message}` line.
-fn report_error(err: &(dyn std::error::Error + 'static)) {
+/// Print an error using the best renderer available:
+///   - JSON mode: serialize [`ErrorEnvelope`] to stderr
+///   - text mode with a config parse failure: clapfig rich/plain
+///   - text mode fallback: plain `Error:` + cause chain
+fn report_error(err: &(dyn std::error::Error + 'static), kind: ErrorKind, format: OutputFormat) {
+    if let OutputFormat::Json = format {
+        let envelope = ErrorEnvelope::new(kind, err);
+        json_output::emit_stderr(&envelope);
+        return;
+    }
+
     if let Some(cfg_err) = find_config_error(err)
         && let Some(clap_err) = cfg_err.to_clapfig_error()
     {
@@ -167,139 +252,253 @@ fn report_error(err: &(dyn std::error::Error + 'static)) {
     }
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
+fn run(cli: &Cli, format: OutputFormat) -> Result<(), CliError> {
+    let json_mode = matches!(format, OutputFormat::Json);
+    let quiet = cli.quiet;
 
-    match cli.command {
-        Command::Scan(args) => {
-            let manifest = scan::scan(&cli.source)?;
+    match &cli.command {
+        Command::Scan(args) => run_scan(cli, args, format),
+        Command::Process(cache_args) => run_process(cli, cache_args, json_mode, quiet),
+        Command::Generate => run_generate(cli, json_mode, quiet),
+        Command::Build(cache_args) => run_build(cli, cache_args, json_mode, quiet),
+        Command::Check => run_check(cli, json_mode, quiet),
+        Command::GenConfig => run_gen_config(json_mode),
+    }
+}
 
-            if let Some(path) = args.save_manifest {
-                let manifest_path = if path.as_os_str() == "__default__" {
-                    cli.temp_dir.join("manifest.json")
-                } else {
-                    path
-                };
-                if let Some(parent) = manifest_path.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                let json = serde_json::to_string_pretty(&manifest)?;
-                std::fs::write(&manifest_path, json)?;
-            }
+fn run_scan(cli: &Cli, args: &ScanArgs, format: OutputFormat) -> Result<(), CliError> {
+    let manifest = scan::scan(&cli.source).tag(ErrorKind::Scan)?;
 
-            match args.format {
-                OutputFormat::Json => {
-                    let json = serde_json::to_string_pretty(&manifest)?;
-                    println!("{}", json);
-                }
-                OutputFormat::Text => {
-                    output::print_scan_output(&manifest, &cli.source);
-                }
-            }
+    let saved_path = if let Some(path) = &args.save_manifest {
+        let manifest_path = if path.as_os_str() == "__default__" {
+            cli.temp_dir.join("manifest.json")
+        } else {
+            path.clone()
+        };
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).tag(ErrorKind::Io)?;
         }
-        Command::Process(cache_args) => {
-            let scan_manifest_path = cli.temp_dir.join("manifest.json");
-            let manifest_content = std::fs::read_to_string(&scan_manifest_path)?;
-            let input_manifest: serde_json::Value = serde_json::from_str(&manifest_content)?;
-            let site_config: config::SiteConfig =
-                serde_json::from_value(input_manifest.get("config").cloned().unwrap_or_default())?;
-            init_thread_pool(&site_config.processing);
-            let processed_dir = cli.temp_dir.join("processed");
-            let (tx, rx) = std::sync::mpsc::channel();
-            let printer = std::thread::spawn(move || {
-                for event in rx {
-                    for line in output::format_process_event(&event) {
-                        println!("{}", line);
-                    }
-                }
-            });
-            let result = process::process(
-                &scan_manifest_path,
-                &cli.source,
-                &processed_dir,
-                !cache_args.no_cache,
-                Some(tx),
-            )?;
-            printer.join().unwrap();
-            let output_manifest = processed_dir.join("manifest.json");
-            let json = serde_json::to_string_pretty(&result.manifest)?;
-            std::fs::write(&output_manifest, &json)?;
-            println!("Cache: {}", result.cache_stats);
+        let json = serde_json::to_string_pretty(&manifest).tag(ErrorKind::Internal)?;
+        std::fs::write(&manifest_path, json).tag(ErrorKind::Io)?;
+        Some(manifest_path)
+    } else {
+        None
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let payload = ScanPayload::new(&manifest, &cli.source, saved_path);
+            let envelope = OkEnvelope::new("scan", payload);
+            json_output::emit_stdout(&envelope);
         }
-        Command::Generate => {
-            let processed_dir = cli.temp_dir.join("processed");
-            let processed_manifest_path = processed_dir.join("manifest.json");
-            generate::generate(
-                &processed_manifest_path,
-                &processed_dir,
-                &cli.output,
-                &cli.source,
-            )?;
-            let manifest_content = std::fs::read_to_string(&processed_manifest_path)?;
-            let manifest: generate::Manifest = serde_json::from_str(&manifest_content)?;
-            output::print_generate_output(&manifest);
-        }
-        Command::Build(cache_args) => {
-            let source = resolve_build_source(&cli.source);
-
-            std::fs::create_dir_all(&cli.temp_dir)?;
-
-            println!("==> Stage 1: Scanning {}", source.display());
-            let manifest = scan::scan(&source)?;
-            let scan_manifest_path = cli.temp_dir.join("manifest.json");
-            let json = serde_json::to_string_pretty(&manifest)?;
-            std::fs::write(&scan_manifest_path, &json)?;
-            output::print_scan_output(&manifest, &source);
-
-            println!("==> Stage 2: Processing images");
-            init_thread_pool(&manifest.config.processing);
-            let processed_dir = cli.temp_dir.join("processed");
-            let (tx, rx) = std::sync::mpsc::channel();
-            let printer = std::thread::spawn(move || {
-                for event in rx {
-                    for line in output::format_process_event(&event) {
-                        println!("{}", line);
-                    }
-                }
-            });
-            let result = process::process(
-                &scan_manifest_path,
-                &source,
-                &processed_dir,
-                !cache_args.no_cache,
-                Some(tx),
-            )?;
-            printer.join().unwrap();
-            let processed_manifest_path = processed_dir.join("manifest.json");
-            let json = serde_json::to_string_pretty(&result.manifest)?;
-            std::fs::write(&processed_manifest_path, &json)?;
-            println!("Cache: {}", result.cache_stats);
-
-            println!("==> Stage 3: Generating HTML → {}", cli.output.display());
-            generate::generate(
-                &processed_manifest_path,
-                &processed_dir,
-                &cli.output,
-                &source,
-            )?;
-            let gen_manifest_content = std::fs::read_to_string(&processed_manifest_path)?;
-            let gen_manifest: generate::Manifest = serde_json::from_str(&gen_manifest_content)?;
-            output::print_generate_output(&gen_manifest);
-
-            println!("==> Build complete: {}", cli.output.display());
-        }
-        Command::Check => {
-            let source = resolve_build_source(&cli.source);
-            println!("==> Checking {}", source.display());
-            let manifest = scan::scan(&source)?;
-            output::print_scan_output(&manifest, &source);
-            println!("==> Content is valid");
-        }
-        Command::GenConfig => {
-            print!("{}", config::stock_config_toml());
+        OutputFormat::Text => {
+            output::print_scan_output(&manifest, &cli.source);
         }
     }
+    Ok(())
+}
 
+fn run_process(
+    cli: &Cli,
+    cache_args: &CacheArgs,
+    json_mode: bool,
+    quiet: bool,
+) -> Result<(), CliError> {
+    let scan_manifest_path = cli.temp_dir.join("manifest.json");
+    let manifest_content = std::fs::read_to_string(&scan_manifest_path).tag(ErrorKind::Io)?;
+    let input_manifest: serde_json::Value =
+        serde_json::from_str(&manifest_content).tag(ErrorKind::Internal)?;
+    let site_config: config::SiteConfig =
+        serde_json::from_value(input_manifest.get("config").cloned().unwrap_or_default())
+            .tag(ErrorKind::Config)?;
+    init_thread_pool(&site_config.processing);
+    let processed_dir = cli.temp_dir.join("processed");
+    let (tx, rx) = std::sync::mpsc::channel();
+    let suppress = json_mode || quiet;
+    let printer = std::thread::spawn(move || {
+        for event in rx {
+            if suppress {
+                continue;
+            }
+            for line in output::format_process_event(&event) {
+                println!("{}", line);
+            }
+        }
+    });
+    let result = process::process(
+        &scan_manifest_path,
+        &cli.source,
+        &processed_dir,
+        !cache_args.no_cache,
+        Some(tx),
+    )
+    .tag(ErrorKind::Process)?;
+    printer.join().unwrap();
+    let output_manifest_path = processed_dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(&result.manifest).tag(ErrorKind::Internal)?;
+    std::fs::write(&output_manifest_path, &json).tag(ErrorKind::Io)?;
+
+    if json_mode {
+        let payload = ProcessPayload {
+            processed_dir: processed_dir.clone(),
+            manifest_path: output_manifest_path,
+            cache: (&result.cache_stats).into(),
+        };
+        json_output::emit_stdout(&OkEnvelope::new("process", payload));
+    } else if !quiet {
+        println!("Cache: {}", result.cache_stats);
+    }
+    Ok(())
+}
+
+fn run_generate(cli: &Cli, json_mode: bool, quiet: bool) -> Result<(), CliError> {
+    let processed_dir = cli.temp_dir.join("processed");
+    let processed_manifest_path = processed_dir.join("manifest.json");
+    generate::generate(
+        &processed_manifest_path,
+        &processed_dir,
+        &cli.output,
+        &cli.source,
+    )
+    .tag(ErrorKind::Generate)?;
+    let manifest_content = std::fs::read_to_string(&processed_manifest_path).tag(ErrorKind::Io)?;
+    let manifest: generate::Manifest =
+        serde_json::from_str(&manifest_content).tag(ErrorKind::Internal)?;
+
+    if json_mode {
+        let payload = GeneratePayload::new(&manifest, &cli.output);
+        json_output::emit_stdout(&OkEnvelope::new("generate", payload));
+    } else if !quiet {
+        output::print_generate_output(&manifest);
+    }
+    Ok(())
+}
+
+fn run_build(
+    cli: &Cli,
+    cache_args: &CacheArgs,
+    json_mode: bool,
+    quiet: bool,
+) -> Result<(), CliError> {
+    let source = resolve_build_source(&cli.source);
+    let stage_text = !json_mode && !quiet;
+
+    std::fs::create_dir_all(&cli.temp_dir).tag(ErrorKind::Io)?;
+
+    if stage_text {
+        println!("==> Stage 1: Scanning {}", source.display());
+    }
+    let manifest = scan::scan(&source).tag(ErrorKind::Scan)?;
+    let scan_manifest_path = cli.temp_dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(&manifest).tag(ErrorKind::Internal)?;
+    std::fs::write(&scan_manifest_path, &json).tag(ErrorKind::Io)?;
+    if stage_text {
+        output::print_scan_output(&manifest, &source);
+        println!("==> Stage 2: Processing images");
+    }
+
+    init_thread_pool(&manifest.config.processing);
+    let processed_dir = cli.temp_dir.join("processed");
+    let (tx, rx) = std::sync::mpsc::channel();
+    let suppress = !stage_text;
+    let printer = std::thread::spawn(move || {
+        for event in rx {
+            if suppress {
+                continue;
+            }
+            for line in output::format_process_event(&event) {
+                println!("{}", line);
+            }
+        }
+    });
+    let result = process::process(
+        &scan_manifest_path,
+        &source,
+        &processed_dir,
+        !cache_args.no_cache,
+        Some(tx),
+    )
+    .tag(ErrorKind::Process)?;
+    printer.join().unwrap();
+    let processed_manifest_path = processed_dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(&result.manifest).tag(ErrorKind::Internal)?;
+    std::fs::write(&processed_manifest_path, &json).tag(ErrorKind::Io)?;
+    if stage_text {
+        println!("Cache: {}", result.cache_stats);
+        println!("==> Stage 3: Generating HTML → {}", cli.output.display());
+    }
+
+    generate::generate(
+        &processed_manifest_path,
+        &processed_dir,
+        &cli.output,
+        &source,
+    )
+    .tag(ErrorKind::Generate)?;
+    let gen_manifest_content =
+        std::fs::read_to_string(&processed_manifest_path).tag(ErrorKind::Io)?;
+    let gen_manifest: generate::Manifest =
+        serde_json::from_str(&gen_manifest_content).tag(ErrorKind::Internal)?;
+
+    if stage_text {
+        output::print_generate_output(&gen_manifest);
+        println!("==> Build complete: {}", cli.output.display());
+    }
+
+    if json_mode {
+        let image_pages: usize = gen_manifest.albums.iter().map(|a| a.images.len()).sum();
+        let pages_count = gen_manifest.pages.iter().filter(|p| !p.is_link).count();
+        let payload = BuildPayload {
+            source: &source,
+            output: &cli.output,
+            counts: simple_gal::json_output::GenerateCounts {
+                albums: gen_manifest.albums.len(),
+                image_pages,
+                pages: pages_count,
+            },
+            cache: CacheStatsPayload::from(&result.cache_stats),
+        };
+        json_output::emit_stdout(&OkEnvelope::new("build", payload));
+    }
+    Ok(())
+}
+
+fn run_check(cli: &Cli, json_mode: bool, quiet: bool) -> Result<(), CliError> {
+    let source = resolve_build_source(&cli.source);
+    if !json_mode && !quiet {
+        println!("==> Checking {}", source.display());
+    }
+    let manifest = scan::scan(&source).tag(ErrorKind::Scan)?;
+    if !json_mode && !quiet {
+        output::print_scan_output(&manifest, &source);
+        println!("==> Content is valid");
+    }
+    if json_mode {
+        let images = manifest.albums.iter().map(|a| a.images.len()).sum();
+        let payload = CheckPayload {
+            valid: true,
+            source: &source,
+            counts: Counts {
+                albums: manifest.albums.len(),
+                images,
+                pages: manifest.pages.len(),
+            },
+        };
+        json_output::emit_stdout(&OkEnvelope::new("check", payload));
+    }
+    Ok(())
+}
+
+fn run_gen_config(json_mode: bool) -> Result<(), CliError> {
+    let toml = config::stock_config_toml();
+    if json_mode {
+        let payload = GenConfigPayload {
+            toml: toml.to_string(),
+        };
+        json_output::emit_stdout(&OkEnvelope::new("gen-config", payload));
+    } else {
+        print!("{toml}");
+    }
     Ok(())
 }
 
@@ -315,6 +514,6 @@ fn init_thread_pool(processing: &config::ProcessingConfig) {
 }
 
 /// Resolve the content source directory for the build command.
-fn resolve_build_source(cli_source: &std::path::Path) -> PathBuf {
+fn resolve_build_source(cli_source: &Path) -> PathBuf {
     cli_source.to_path_buf()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,18 @@ fn is_io_error(err: &(dyn std::error::Error + 'static)) -> bool {
     false
 }
 
+/// Join the progress-printer thread and convert any panic from that
+/// thread into a tagged [`CliError`]. The printer only formats events
+/// and writes to stdout, so a panic here is very unusual — but in JSON
+/// mode we've promised exactly one envelope, and an unwrap would both
+/// skip the envelope and bypass the exit-code mapping.
+fn join_printer(handle: std::thread::JoinHandle<()>) -> Result<(), CliError> {
+    handle.join().map_err(|_| {
+        let msg: Box<dyn std::error::Error + 'static> = "progress printer thread panicked".into();
+        CliError::new(ErrorKind::Internal, msg)
+    })
+}
+
 trait TagError<T> {
     fn tag(self, kind: ErrorKind) -> Result<T, CliError>;
 }
@@ -202,7 +214,7 @@ fn resolve_format(cli: &Cli) -> OutputFormat {
     if let Some(fmt) = cli.format {
         return fmt;
     }
-    match cli.command {
+    match &cli.command {
         Command::Scan(_) => OutputFormat::Json,
         _ => OutputFormat::Text,
     }
@@ -229,7 +241,12 @@ fn find_config_error<'a>(
 fn report_error(err: &(dyn std::error::Error + 'static), kind: ErrorKind, format: OutputFormat) {
     if let OutputFormat::Json = format {
         let envelope = ErrorEnvelope::new(kind, err);
-        json_output::emit_stderr(&envelope);
+        if let Err(ser_err) = json_output::emit_stderr(&envelope) {
+            // Serializing the envelope itself failed (extraordinarily
+            // unlikely given the shapes involved) — fall back to a plain
+            // line so the user at least sees *something*.
+            eprintln!("Error: failed to render error envelope: {ser_err}");
+        }
         return;
     }
 
@@ -289,10 +306,12 @@ fn run_scan(cli: &Cli, args: &ScanArgs, format: OutputFormat) -> Result<(), CliE
         OutputFormat::Json => {
             let payload = ScanPayload::new(&manifest, &cli.source, saved_path);
             let envelope = OkEnvelope::new("scan", payload);
-            json_output::emit_stdout(&envelope);
+            json_output::emit_stdout(&envelope).tag(ErrorKind::Internal)?;
         }
         OutputFormat::Text => {
-            output::print_scan_output(&manifest, &cli.source);
+            if !cli.quiet {
+                output::print_scan_output(&manifest, &cli.source);
+            }
         }
     }
     Ok(())
@@ -333,7 +352,7 @@ fn run_process(
         Some(tx),
     )
     .tag(ErrorKind::Process)?;
-    printer.join().unwrap();
+    join_printer(printer)?;
     let output_manifest_path = processed_dir.join("manifest.json");
     let json = serde_json::to_string_pretty(&result.manifest).tag(ErrorKind::Internal)?;
     std::fs::write(&output_manifest_path, &json).tag(ErrorKind::Io)?;
@@ -344,7 +363,7 @@ fn run_process(
             manifest_path: output_manifest_path,
             cache: (&result.cache_stats).into(),
         };
-        json_output::emit_stdout(&OkEnvelope::new("process", payload));
+        json_output::emit_stdout(&OkEnvelope::new("process", payload)).tag(ErrorKind::Internal)?;
     } else if !quiet {
         println!("Cache: {}", result.cache_stats);
     }
@@ -367,7 +386,7 @@ fn run_generate(cli: &Cli, json_mode: bool, quiet: bool) -> Result<(), CliError>
 
     if json_mode {
         let payload = GeneratePayload::new(&manifest, &cli.output);
-        json_output::emit_stdout(&OkEnvelope::new("generate", payload));
+        json_output::emit_stdout(&OkEnvelope::new("generate", payload)).tag(ErrorKind::Internal)?;
     } else if !quiet {
         output::print_generate_output(&manifest);
     }
@@ -419,7 +438,7 @@ fn run_build(
         Some(tx),
     )
     .tag(ErrorKind::Process)?;
-    printer.join().unwrap();
+    join_printer(printer)?;
     let processed_manifest_path = processed_dir.join("manifest.json");
     let json = serde_json::to_string_pretty(&result.manifest).tag(ErrorKind::Internal)?;
     std::fs::write(&processed_manifest_path, &json).tag(ErrorKind::Io)?;
@@ -458,7 +477,7 @@ fn run_build(
             },
             cache: CacheStatsPayload::from(&result.cache_stats),
         };
-        json_output::emit_stdout(&OkEnvelope::new("build", payload));
+        json_output::emit_stdout(&OkEnvelope::new("build", payload)).tag(ErrorKind::Internal)?;
     }
     Ok(())
 }
@@ -484,7 +503,7 @@ fn run_check(cli: &Cli, json_mode: bool, quiet: bool) -> Result<(), CliError> {
                 pages: manifest.pages.len(),
             },
         };
-        json_output::emit_stdout(&OkEnvelope::new("check", payload));
+        json_output::emit_stdout(&OkEnvelope::new("check", payload)).tag(ErrorKind::Internal)?;
     }
     Ok(())
 }
@@ -495,7 +514,8 @@ fn run_gen_config(json_mode: bool) -> Result<(), CliError> {
         let payload = GenConfigPayload {
             toml: toml.to_string(),
         };
-        json_output::emit_stdout(&OkEnvelope::new("gen-config", payload));
+        json_output::emit_stdout(&OkEnvelope::new("gen-config", payload))
+            .tag(ErrorKind::Internal)?;
     } else {
         print!("{toml}");
     }

--- a/tests/cli_config_errors.rs
+++ b/tests/cli_config_errors.rs
@@ -68,12 +68,20 @@ fn build_with_bad_config_renders_clapfig_plain_error() {
 
 #[test]
 fn scan_with_bad_config_renders_clapfig_plain_error() {
-    // Same check for the scan command, which also touches config loading.
+    // Same check for the scan command. `scan` defaults to JSON output, so
+    // we have to explicitly ask for text mode to exercise the clapfig
+    // renderer path (JSON mode is covered by cli_json.rs).
     let tmp = TempDir::new().unwrap();
     write_bad_config(tmp.path());
 
     let output = simple_gal()
-        .args(["--source", tmp.path().to_str().unwrap(), "scan"])
+        .args([
+            "--source",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "scan",
+        ])
         .output()
         .expect("failed to run simple-gal");
 

--- a/tests/cli_json.rs
+++ b/tests/cli_json.rs
@@ -1,0 +1,199 @@
+//! Integration tests for the `--format json` envelope contract.
+//!
+//! Every command emits a tagged `OkEnvelope` on success (`{ok: true, command,
+//! data}`) and an `ErrorEnvelope` on failure (`{ok: false, kind, message,
+//! causes, config?}`). Exit codes map to the `ErrorKind`. These tests pin that
+//! contract so automation clients can rely on it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn simple_gal() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_simple-gal"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/content")
+}
+
+fn parse_json(bytes: &[u8]) -> serde_json::Value {
+    let s = String::from_utf8_lossy(bytes);
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("not valid JSON: {e}\n---\n{s}\n---"))
+}
+
+// ============================================================================
+// Success envelopes
+// ============================================================================
+
+#[test]
+fn check_json_envelope() {
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--format",
+            "json",
+            "check",
+        ])
+        .output()
+        .expect("run simple-gal");
+    assert!(output.status.success(), "exit={}", output.status);
+    let v = parse_json(&output.stdout);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "check");
+    assert_eq!(v["data"]["valid"], true);
+    assert!(v["data"]["counts"]["albums"].as_u64().unwrap() > 0);
+}
+
+#[test]
+fn gen_config_json_envelope() {
+    let output = simple_gal()
+        .args(["--format", "json", "gen-config"])
+        .output()
+        .expect("run simple-gal");
+    assert!(output.status.success());
+    let v = parse_json(&output.stdout);
+    assert_eq!(v["command"], "gen-config");
+    let toml = v["data"]["toml"].as_str().unwrap();
+    assert!(toml.contains("site_title"));
+}
+
+#[test]
+fn scan_envelope_has_counts_and_source() {
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--format",
+            "json",
+            "scan",
+        ])
+        .output()
+        .expect("run simple-gal");
+    assert!(output.status.success());
+    let v = parse_json(&output.stdout);
+    assert_eq!(v["command"], "scan");
+    assert!(v["data"]["counts"]["albums"].as_u64().unwrap() > 0);
+    assert!(v["data"]["counts"]["images"].as_u64().unwrap() > 0);
+    assert!(v["data"]["manifest"]["navigation"].is_array());
+}
+
+// ============================================================================
+// Error envelopes + exit codes
+// ============================================================================
+
+#[test]
+fn config_error_json_envelope() {
+    // Unquoted CSS value — the same kind of failure clapfig renders in text
+    // mode. In JSON mode it becomes an ErrorEnvelope on stderr with kind
+    // "config", a snippet, line, column, and exit code 3.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("config.toml"),
+        "site_title = \"Bad\"\n\n[theme]\nthumbnail_gap = 0.1rem\n",
+    )
+    .unwrap();
+
+    let output = simple_gal()
+        .args([
+            "--source",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "scan",
+        ])
+        .output()
+        .expect("run simple-gal");
+
+    assert!(!output.status.success(), "should fail on bad config");
+    assert_eq!(output.status.code(), Some(3), "config error exit code");
+
+    // stdout must be empty: on failure the envelope goes to stderr.
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty on error, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let v = parse_json(&output.stderr);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["kind"], "config");
+    assert!(!v["message"].as_str().unwrap().is_empty());
+    let cfg = &v["config"];
+    assert!(cfg["path"].as_str().unwrap().ends_with("config.toml"));
+    assert_eq!(cfg["line"], 4);
+    assert!(cfg["snippet"].as_str().unwrap().contains("thumbnail_gap"));
+}
+
+#[test]
+fn scan_error_json_envelope_missing_source() {
+    // Nonexistent source directory — scan stage fails with an IO error.
+    // stage classification wins: kind="scan", exit code = 5.
+    let output = simple_gal()
+        .args([
+            "--source",
+            "/definitely/does/not/exist/xyz-simplegal-test",
+            "--format",
+            "json",
+            "scan",
+        ])
+        .output()
+        .expect("run simple-gal");
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(5));
+    assert!(output.stdout.is_empty());
+    let v = parse_json(&output.stderr);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["kind"], "scan");
+}
+
+#[test]
+fn text_mode_error_does_not_emit_json() {
+    // Regression: in text mode the error path stays human-readable; no
+    // stray JSON on stderr.
+    let output = simple_gal()
+        .args([
+            "--source",
+            "/definitely/does/not/exist/xyz-simplegal-test",
+            "--format",
+            "text",
+            "scan",
+        ])
+        .output()
+        .expect("run simple-gal");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.starts_with("Error:"));
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stderr).is_err(),
+        "text-mode stderr must not be JSON: {stderr}"
+    );
+}
+
+// ============================================================================
+// --quiet
+// ============================================================================
+
+#[test]
+fn quiet_suppresses_text_output() {
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--quiet",
+            "check",
+        ])
+        .output()
+        .expect("run simple-gal");
+
+    assert!(output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "--quiet should suppress stdout in text mode, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/tests/cli_json.rs
+++ b/tests/cli_json.rs
@@ -127,14 +127,22 @@ fn config_error_json_envelope() {
     assert!(cfg["snippet"].as_str().unwrap().contains("thumbnail_gap"));
 }
 
+/// Build a guaranteed-nonexistent path inside a `TempDir` (portable
+/// across Unix/Windows, and doesn't collide with anything real).
+fn missing_source(tmp: &TempDir) -> PathBuf {
+    tmp.path().join("does-not-exist-xyz")
+}
+
 #[test]
 fn scan_error_json_envelope_missing_source() {
     // Nonexistent source directory — scan stage fails with an IO error.
     // stage classification wins: kind="scan", exit code = 5.
+    let tmp = TempDir::new().unwrap();
+    let missing = missing_source(&tmp);
     let output = simple_gal()
         .args([
             "--source",
-            "/definitely/does/not/exist/xyz-simplegal-test",
+            missing.to_str().unwrap(),
             "--format",
             "json",
             "scan",
@@ -154,10 +162,12 @@ fn scan_error_json_envelope_missing_source() {
 fn text_mode_error_does_not_emit_json() {
     // Regression: in text mode the error path stays human-readable; no
     // stray JSON on stderr.
+    let tmp = TempDir::new().unwrap();
+    let missing = missing_source(&tmp);
     let output = simple_gal()
         .args([
             "--source",
-            "/definitely/does/not/exist/xyz-simplegal-test",
+            missing.to_str().unwrap(),
             "--format",
             "text",
             "scan",
@@ -194,6 +204,30 @@ fn quiet_suppresses_text_output() {
     assert!(
         output.stdout.is_empty(),
         "--quiet should suppress stdout in text mode, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn quiet_suppresses_scan_text_tree() {
+    // `scan` has a text-mode renderer too; --quiet must suppress it
+    // just like every other command.
+    let output = simple_gal()
+        .args([
+            "--source",
+            fixtures_dir().to_str().unwrap(),
+            "--format",
+            "text",
+            "--quiet",
+            "scan",
+        ])
+        .output()
+        .expect("run simple-gal");
+
+    assert!(output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "--quiet should suppress scan's text tree, got: {}",
         String::from_utf8_lossy(&output.stdout)
     );
 }

--- a/tests/cli_scan.rs
+++ b/tests/cli_scan.rs
@@ -31,9 +31,14 @@ fn scan_default_format_is_json() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("default output should be valid JSON");
-    assert!(parsed.get("navigation").is_some());
-    assert!(parsed.get("albums").is_some());
-    assert!(parsed.get("config").is_some());
+    // New envelope format: ok/command/data wrapper around the manifest.
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["command"], "scan");
+    let data = &parsed["data"];
+    assert!(data.get("manifest").is_some());
+    assert!(data["manifest"].get("navigation").is_some());
+    assert!(data["manifest"].get("albums").is_some());
+    assert!(data.get("counts").is_some());
 }
 
 #[test]
@@ -42,9 +47,9 @@ fn scan_format_json_outputs_valid_manifest() {
         .args([
             "--source",
             fixtures_dir().to_str().unwrap(),
-            "scan",
             "--format",
             "json",
+            "scan",
         ])
         .output()
         .expect("failed to run simple-gal");
@@ -53,7 +58,7 @@ fn scan_format_json_outputs_valid_manifest() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    let albums = parsed["albums"].as_array().unwrap();
+    let albums = parsed["data"]["manifest"]["albums"].as_array().unwrap();
     assert!(!albums.is_empty(), "should discover at least one album");
 }
 
@@ -63,9 +68,9 @@ fn scan_format_text_outputs_tree() {
         .args([
             "--source",
             fixtures_dir().to_str().unwrap(),
-            "scan",
             "--format",
             "text",
+            "scan",
         ])
         .output()
         .expect("failed to run simple-gal");
@@ -181,9 +186,9 @@ fn scan_text_format_with_save_manifest() {
             fixtures_dir().to_str().unwrap(),
             "--temp-dir",
             tmp.path().to_str().unwrap(),
-            "scan",
             "--format",
             "text",
+            "scan",
             "--save-manifest",
         ])
         .output()
@@ -195,7 +200,7 @@ fn scan_text_format_with_save_manifest() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Albums"));
 
-    // but the file is JSON
+    // but the file is JSON — saved_manifest is always the raw scan manifest
     assert!(manifest_path.exists());
     let content = std::fs::read_to_string(&manifest_path).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -213,9 +218,9 @@ fn scan_json_format_with_save_manifest() {
             fixtures_dir().to_str().unwrap(),
             "--temp-dir",
             tmp.path().to_str().unwrap(),
-            "scan",
             "--format",
             "json",
+            "scan",
             "--save-manifest",
         ])
         .output()
@@ -223,11 +228,18 @@ fn scan_json_format_with_save_manifest() {
 
     assert!(output.status.success());
 
-    // stdout is JSON
+    // stdout is the envelope
     let stdout = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str::<serde_json::Value>(&stdout).expect("stdout should be valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(
+        parsed["data"]["saved_manifest_path"],
+        manifest_path.to_string_lossy().as_ref()
+    );
 
-    // file is also JSON
+    // file is the raw manifest (albums at top level)
     let content = std::fs::read_to_string(&manifest_path).unwrap();
-    serde_json::from_str::<serde_json::Value>(&content).expect("saved file should be valid JSON");
+    let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(saved.get("albums").is_some());
 }


### PR DESCRIPTION
## Summary

Makes simple-gal scriptable from shells and GUIs without scraping human-readable text.

- **Global `--format {text,json}` flag** — promotes the former scan-only flag to a global. Every command, in JSON mode, emits exactly one tagged envelope to stdout (success) or stderr (error) so callers can always `jq` it. `scan` keeps its JSON default from v0.12; every other command defaults to text.
- **Structured error envelopes** with a `kind` field (`config`, `io`, `scan`, `process`, `generate`, `validation`, `usage`, `internal`) and a `config` payload carrying `path` / `line` / `column` / `snippet` on TOML parse failures — same info clapfig shows in text mode, now programmatically available so a GUI can highlight the exact token.
- **Granular exit codes** drive off `ErrorKind` — `3` config, `4` io, `5` scan, `6` process, `7` generate, `8` validation — so scripts can branch without parsing messages. Previously every failure was `1`.
- **`--quiet`** suppresses non-error stdout in text mode (JSON mode is already a single document, so it's a no-op there).
- **Stream hygiene** — in JSON mode, stage headers (`==> Stage N:`), per-image cache status lines, and cache summary prints are suppressed so stdout stays a single clean document. On failure stdout is empty and the envelope goes to stderr.

Implementation lives in a new `src/json_output.rs` module that defines the on-the-wire types (`OkEnvelope<T>`, `ErrorEnvelope`, `ScanPayload`, `ProcessPayload`, `GeneratePayload`, `BuildPayload`, `CheckPayload`, `GenConfigPayload`). `main.rs` wraps each command result with `.tag(ErrorKind::…)` so classification happens at the call site; a downcast walk re-classifies as `Config` whenever a `ConfigError` is found anywhere in the source chain.

Deliberately deferred (flagged in the discussion, not in this PR): multi-error `check` collection, NDJSON progress events on stderr, `--version` subcommand, JSON output schemas doc.

## Test plan

- [x] `cargo test` — all 413 tests pass (395 unit, 2 cli_config_errors, 8 cli_scan, 7 new cli_json, 1 doctest)
- [x] `cargo build` clean (no new clippy warnings from this change)
- [x] Smoke-tested each command in JSON mode against `fixtures/content`: `scan`, `check`, `process`, `generate`, `build`, `gen-config` all emit clean envelopes
- [x] Smoke-tested JSON error envelope paths: bad config (exit 3, snippet populated), missing source dir (exit 5, kind=scan)
- [x] Smoke-tested text mode is unchanged for `build` and error rendering for config failures still goes through clapfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)