### PR TITLE
Offload site config to clapfig + confique; add `simple-gal config` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `simple-gal config` subcommand group, owned end-to-end by [`clapfig`](https://crates.io/crates/clapfig) 0.15: `config gen` (commented TOML template auto-derived from `SiteConfig` doc comments + `#[config(default = ...)]` annotations), `config schema` (JSON Schema, Draft 2020-12, intended for GUI form generators), `config list` (flat dotted-key view of the resolved config), `config get KEY` (single key + doc comment), and `config set KEY VALUE` / `config unset KEY` placeholders that error with a clear `NoPersistPath` until a persist scope is wired. All variants honor `--format json` via the new `ConfigOpPayload` envelope (`{ok, command: "config", data: {action, ...}}`), so automation can consume any of them without scraping text.
+- `--source content config schema -o site.schema.json` writes the JSON Schema to a file. The schema includes per-field `default`, `description` (from doc comments), `type`, and `additionalProperties: false` on every nested object.
+
+### Changed
+- **`SiteConfig` migrated to [`confique::Config`](https://crates.io/crates/confique).** Defaults now live as `#[config(default = ...)]` on the struct fields, sparse loading + deep merge are handled by confique's generated `Layer` type, and the per-directory cascade in `scan.rs` threads `SiteConfigLayer` instead of resolved `SiteConfig`s, folding layers via `Layer::with_fallback` and finalizing only at album leaves. Net delete: ~430 lines of `PartialSiteConfig`, hand-written `merge()` methods, and the hand-rolled `stock_config_toml()` template string.
+- A custom `Deserialize` impl on `SiteConfig` routes any direct deserialize (manifest reads in `process.rs`, JSON test fixtures, anything calling `serde_json::from_str::<SiteConfig>`) through the same layer + defaults pipeline, so a sparse `"config": {}` in a manifest still produces a fully-populated config.
+- `simple-gal gen-config` removed in favor of `simple-gal config gen`. The new template is auto-generated from confique struct metadata, so it can no longer drift from the code.
+- `--output` is no longer a global flag — only `build` and `generate` use it, and marking it global collided with clapfig's `config gen --output` / `config schema --output`. `--source` and `--temp-dir` are still global.
+- `ColorScheme` was split into distinct `LightColors` / `DarkColors` types, and `ClampSize` into `MatX` / `MatY`. confique nested defaults come from the inner type, so two instances of one type can't have different defaults; splitting is the only way to keep accurate per-side defaults visible in both the schema and the generated template.
+- Semantic validation (`quality ≤ 100`, non-zero aspect ratios, non-empty `images.sizes`) now runs through clapfig's `.post_validate()` hook on every `simple-gal config <action>` invocation. The standalone `SiteConfig::validate()` method stays for the per-directory cascade in `scan.rs`.
+- `clapfig` bumped from 0.13 → 0.15. Adds `confique = "0.4"` as a direct dependency (used for the `Config` derive macro and `Layer` trait).
+
 ## [0.14.0] - 2026-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,15 +394,17 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clapfig"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74d81b0df452433e29c223509993da940d6311edec605a4a9b2a099c47d2eee"
+checksum = "f7192cac8f20bbd67ffcc621a9b6d4c59562d561ebb6ecf5086a486aa05c87f4"
 dependencies = [
+ "clap",
  "confique",
  "directories",
  "miette",
  "serde",
  "serde_ignored",
+ "serde_json",
  "thiserror",
  "toml 0.8.23",
  "toml_edit",
@@ -1892,6 +1894,7 @@ dependencies = [
  "avif-parse",
  "clap",
  "clapfig",
+ "confique",
  "headless_chrome",
  "image",
  "maud",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ exclude = ["fixtures/", "tests/", "scripts/", "*.config.*", "package.json", "pac
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-# Used solely for structured error data + plain/rich (miette) renderers on
-# config file parse failures. We do not use clapfig's config loader — keeping
-# default-features off skips the clap adapter we don't need.
-clapfig = { version = "0.13", default-features = false, features = ["rich-errors"] }
+# clapfig owns site config: layered loading via the confique-derived
+# `SiteConfig`, the `simple-gal config` subcommand group (gen|get|set|list|
+# schema|unset), per-directory cascade via `Resolver::resolve_at`, and
+# rich/plain rendering of TOML parse errors.
+clapfig = { version = "0.15", default-features = false, features = ["clap", "rich-errors"] }
+confique = { version = "0.4", default-features = false, features = ["toml"] }
 image = { version = "0.25", default-features = false, features = [
     "jpeg", "png", "tiff", "webp",
     "avif",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,103 +1,79 @@
 //! Site configuration module.
 //!
-//! Handles loading, validating, and merging `config.toml` files. Configuration
-//! is hierarchical: stock defaults are overridden by user config files at any
-//! level of the directory tree (root → group → gallery).
+//! `SiteConfig` is a [confique][confique::Config] struct: defaults live as
+//! `#[config(default = ...)]` annotations on the fields, sparse loading +
+//! deep merge are handled by confique's generated `Layer` type, and the
+//! [`simple-gal config`][crate] CLI subcommand group is wired through
+//! [clapfig][clapfig].
 //!
-//! ## Config File Location
+//! ## Per-directory cascade
 //!
-//! Place `config.toml` in the content root and/or any album group or album directory:
+//! Site config is hierarchical: a `config.toml` may live in the content
+//! root, in any album group, and in any album directory. The scan stage
+//! walks the tree and merges every `config.toml` it finds onto its parent's
+//! resolved config, so each album sees its own combined view (root → group
+//! → gallery). The cascade machinery lives in `scan.rs`; this module owns
+//! the type, defaults, validation, and CSS-emitting helpers consumed by
+//! `generate.rs`.
 //!
-//! ```text
-//! content/
-//! ├── config.toml              # Root config (overrides stock defaults)
-//! ├── 010-Landscapes/
-//! │   └── ...
-//! └── 020-Travel/
-//!     ├── config.toml          # Group config (overrides root)
-//!     ├── 010-Japan/
-//!     │   ├── config.toml      # Gallery config (overrides group)
-//!     │   └── ...
-//!     └── 020-Italy/
-//!         └── ...
-//! ```
-//!
-//! ## Configuration Options
+//! ## Configuration shape
 //!
 //! ```toml
-//! # All options are optional - defaults shown below
-//!
-//! content_root = "content"  # Path to content directory (root-level only)
-//! site_title = "Gallery"    # Breadcrumb home label and index page title
+//! site_title = "Gallery"
+//! assets_dir = "assets"
 //!
 //! [thumbnails]
-//! aspect_ratio = [4, 5]     # width:height ratio
+//! aspect_ratio = [4, 5]
+//! size = 400
 //!
 //! [full_index]
-//! generates = false         # If true, render an "All Photos" page with every image
-//! show_link = false         # If true, add an "All Photos" item to the nav menu
-//! thumb_ratio = [4, 5]      # Aspect ratio for full-index thumbnails
-//! thumb_size = 400          # Short-edge size in pixels for full-index thumbnails
-//! thumb_gap = "0.2rem"      # Gap between thumbnails on the All Photos grid
+//! generates = false
+//! show_link = false
+//! thumb_ratio = [4, 5]
+//! thumb_size = 400
+//! thumb_gap = "0.2rem"
 //!
 //! [images]
-//! sizes = [800, 1400, 2080] # Responsive sizes to generate
-//! quality = 90              # AVIF quality (0-100)
+//! sizes = [800, 1400, 2080]
+//! quality = 90
 //!
 //! [theme]
-//! thumbnail_gap = "0.2rem"  # Gap between thumbnails in grids
-//! grid_padding = "2rem"     # Padding around thumbnail grids
+//! thumbnail_gap = "0.2rem"
+//! grid_padding = "2rem"
 //!
 //! [theme.mat_x]
-//! size = "3vw"              # Preferred horizontal mat size
-//! min = "1rem"              # Minimum horizontal mat size
-//! max = "2.5rem"            # Maximum horizontal mat size
+//! size = "3vw"
+//! min  = "1rem"
+//! max  = "2.5rem"
 //!
 //! [theme.mat_y]
-//! size = "6vw"              # Preferred vertical mat size
-//! min = "2rem"              # Minimum vertical mat size
-//! max = "5rem"              # Maximum vertical mat size
+//! size = "6vw"
+//! min  = "2rem"
+//! max  = "5rem"
 //!
 //! [colors.light]
 //! background = "#ffffff"
-//! text = "#111111"
-//! text_muted = "#666666"    # Nav menu, breadcrumbs, captions
-//! border = "#e0e0e0"
-//! separator = "#e0e0e0"
-//! link = "#333333"
-//! link_hover = "#000000"
+//! # ...
 //!
 //! [colors.dark]
 //! background = "#000000"
-//! text = "#fafafa"
-//! text_muted = "#999999"
-//! border = "#333333"
-//! separator = "#333333"
-//! link = "#cccccc"
-//! link_hover = "#ffffff"
+//! # ...
 //!
 //! [font]
-//! font = "Noto Sans"    # Google Fonts family name
-//! weight = "600"            # Font weight to load
-//! font_type = "sans"        # "sans" or "serif" (determines fallbacks)
+//! font = "Noto Sans"
+//! weight = "600"
+//! font_type = "sans"
 //!
 //! [processing]
-//! max_processes = 4         # Max parallel workers (omit for auto = CPU cores)
-//!
+//! # max_processes = 4   # omit for auto-detect
 //! ```
 //!
-//! ## Partial Configuration
-//!
-//! Config files are sparse — override just the values you want:
-//!
-//! ```toml
-//! # Only override the light mode background
-//! [colors.light]
-//! background = "#fafafa"
-//! ```
-//!
-//! Unknown keys are rejected to catch typos early.
+//! Run `simple-gal config gen` to print a documented template derived
+//! directly from this struct.
 
+use confique::Config;
+use confique::Layer;
+use confique::meta::Meta;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -120,6 +96,11 @@ pub enum ConfigError {
         source: Box<toml::de::Error>,
         source_text: String,
     },
+    /// confique's deserialize/build error from converting a merged layer
+    /// into the typed `SiteConfig`. Distinct from `Toml` because it can
+    /// fire on a layer that came from multiple files.
+    #[error("config error: {0}")]
+    Confique(#[from] confique::Error),
     #[error("Config validation error: {0}")]
     Validation(String),
 }
@@ -146,87 +127,104 @@ impl ConfigError {
     }
 }
 
+// =============================================================================
+// SiteConfig — top level
+// =============================================================================
+
 /// Site configuration loaded from `config.toml`.
 ///
 /// All fields have sensible defaults. User config files need only specify
 /// the values they want to override. Unknown keys are rejected.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+//
+// Note: `Deserialize` is implemented manually below so that any caller
+// reading a `SiteConfig` from JSON or TOML — including the manifest reader
+// in `process.rs` — gets the same sparse-tolerant + default-merge semantics
+// as `load_config`. Kept as a regular comment so it doesn't leak into the
+// schema/template doc strings.
+#[derive(Config, Debug, Clone, Serialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
 pub struct SiteConfig {
     /// Site title used in breadcrumbs and the browser tab for the home page.
-    #[serde(default = "default_site_title")]
+    #[config(default = "Gallery")]
     pub site_title: String,
-    /// Directory for static assets (favicon, fonts, etc.), relative to content root.
-    /// Contents are copied verbatim to the output root during generation.
-    #[serde(default = "default_assets_dir")]
+
+    /// Directory for static assets (favicon, fonts, etc.), relative to
+    /// content root. Contents are copied verbatim to the output root during
+    /// generation. If the directory doesn't exist, it is silently skipped.
+    #[config(default = "assets")]
     pub assets_dir: String,
-    /// Stem of the site description file in the content root (e.g. "site" →
-    /// looks for `site.md` / `site.txt`). Rendered on the index page.
-    #[serde(default = "default_site_description_file")]
+
+    /// Stem of the site description file in the content root (e.g. `site`
+    /// → looks for `site.md` / `site.txt`). Rendered on the index page.
+    #[config(default = "site")]
     pub site_description_file: String,
+
     /// Color schemes for light and dark modes.
+    #[config(nested)]
     pub colors: ColorConfig,
-    /// Thumbnail generation settings (aspect ratio).
+
+    /// Thumbnail generation settings (aspect ratio, size).
+    #[config(nested)]
     pub thumbnails: ThumbnailsConfig,
+
     /// Site-wide "All Photos" index settings.
+    #[config(nested)]
     pub full_index: FullIndexConfig,
+
     /// Responsive image generation settings (sizes, quality).
+    #[config(nested)]
     pub images: ImagesConfig,
-    /// Theme/layout settings (frame padding, grid spacing).
+
+    /// Theme / layout settings (mats, grid spacing).
+    #[config(nested)]
     pub theme: ThemeConfig,
+
     /// Font configuration (Google Fonts or local font file).
+    #[config(nested)]
     pub font: FontConfig,
+
     /// Parallel processing settings.
+    #[config(nested)]
     pub processing: ProcessingConfig,
 }
 
-/// Partial site configuration for sparse loading and strict validation.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialSiteConfig {
-    pub site_title: Option<String>,
-    pub assets_dir: Option<String>,
-    pub site_description_file: Option<String>,
-    pub colors: Option<PartialColorConfig>,
-    pub thumbnails: Option<PartialThumbnailsConfig>,
-    pub full_index: Option<PartialFullIndexConfig>,
-    pub images: Option<PartialImagesConfig>,
-    pub theme: Option<PartialThemeConfig>,
-    pub font: Option<PartialFontConfig>,
-    pub processing: Option<PartialProcessingConfig>,
-}
-
-fn default_site_title() -> String {
-    "Gallery".to_string()
-}
-
-fn default_assets_dir() -> String {
-    "assets".to_string()
-}
-
-fn default_site_description_file() -> String {
-    "site".to_string()
-}
-
 impl Default for SiteConfig {
+    /// Construct a `SiteConfig` populated entirely from confique-declared
+    /// defaults. Used by tests and by the scan stage to seed the cascade
+    /// before any user `config.toml` is layered on.
     fn default() -> Self {
-        Self {
-            site_title: default_site_title(),
-            assets_dir: default_assets_dir(),
-            site_description_file: default_site_description_file(),
-            colors: ColorConfig::default(),
-            thumbnails: ThumbnailsConfig::default(),
-            full_index: FullIndexConfig::default(),
-            images: ImagesConfig::default(),
-            theme: ThemeConfig::default(),
-            font: FontConfig::default(),
-            processing: ProcessingConfig::default(),
-        }
+        let layer = <SiteConfig as Config>::Layer::default_values();
+        SiteConfig::from_layer(layer).expect("confique defaults must satisfy the SiteConfig schema")
+    }
+}
+
+impl<'de> Deserialize<'de> for SiteConfig {
+    /// Custom deserialize that funnels any input (TOML config file, JSON
+    /// manifest field, test fixture) through the same sparse-layer +
+    /// fill-defaults pipeline `load_config` uses.
+    ///
+    /// Without this, missing fields on a directly-deserialized `SiteConfig`
+    /// would be hard errors instead of falling through to confique-declared
+    /// defaults — which would force every manifest writer (and every test
+    /// fixture) to spell out every field explicitly.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let layer = SiteConfigLayer::deserialize(deserializer)?;
+        let merged = layer.with_fallback(SiteConfigLayer::default_values());
+        SiteConfig::from_layer(merged).map_err(serde::de::Error::custom)
     }
 }
 
 impl SiteConfig {
-    /// Validate config values are within acceptable ranges.
+    /// Validate semantic constraints that confique's type system can't
+    /// express: numeric ranges, non-empty arrays, and so on.
+    ///
+    /// Wired into clapfig's `.post_validate()` hook in [`load_config`] so
+    /// every loaded config (CLI, cascade leaf, test fixture) runs the same
+    /// checks.
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.images.quality > 100 {
             return Err(ConfigError::Validation(
@@ -255,67 +253,228 @@ impl SiteConfig {
         }
         Ok(())
     }
+}
 
-    /// Merge a partial config on top of this one.
-    pub fn merge(mut self, other: PartialSiteConfig) -> Self {
-        if let Some(st) = other.site_title {
-            self.site_title = st;
-        }
-        if let Some(ad) = other.assets_dir {
-            self.assets_dir = ad;
-        }
-        if let Some(sd) = other.site_description_file {
-            self.site_description_file = sd;
-        }
-        if let Some(c) = other.colors {
-            self.colors = self.colors.merge(c);
-        }
-        if let Some(t) = other.thumbnails {
-            self.thumbnails = self.thumbnails.merge(t);
-        }
-        if let Some(fi) = other.full_index {
-            self.full_index = self.full_index.merge(fi);
-        }
-        if let Some(i) = other.images {
-            self.images = self.images.merge(i);
-        }
-        if let Some(t) = other.theme {
-            self.theme = self.theme.merge(t);
-        }
-        if let Some(f) = other.font {
-            self.font = self.font.merge(f);
-        }
-        if let Some(p) = other.processing {
-            self.processing = self.processing.merge(p);
-        }
-        self
+// =============================================================================
+// Thumbnails
+// =============================================================================
+
+/// Thumbnail generation settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct ThumbnailsConfig {
+    /// Aspect ratio as `[width, height]`, e.g. `[4, 5]` for portrait.
+    #[config(default = [4, 5])]
+    pub aspect_ratio: [u32; 2],
+    /// Thumbnail short-edge size in pixels.
+    #[config(default = 400)]
+    pub size: u32,
+}
+
+// =============================================================================
+// Full index ("All Photos")
+// =============================================================================
+
+/// Settings for the site-wide "All Photos" index page.
+///
+/// When `generates` is true, the generate stage renders an extra page at
+/// `/all-photos/` showing every image from every public album in a single
+/// thumbnail grid. Thumbnails are generated at the ratio/size specified
+/// here, independent of the regular per-album `[thumbnails]` settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct FullIndexConfig {
+    /// Whether the All Photos page is rendered.
+    #[config(default = false)]
+    pub generates: bool,
+    /// Whether to add an "All Photos" item to the navigation menu.
+    #[config(default = false)]
+    pub show_link: bool,
+    /// Aspect ratio `[width, height]` for full-index thumbnails.
+    #[config(default = [4, 5])]
+    pub thumb_ratio: [u32; 2],
+    /// Short-edge size (in pixels) for full-index thumbnails.
+    #[config(default = 400)]
+    pub thumb_size: u32,
+    /// Gap between thumbnails on the All Photos grid (CSS value).
+    #[config(default = "0.2rem")]
+    pub thumb_gap: String,
+}
+
+// =============================================================================
+// Images
+// =============================================================================
+
+/// Responsive image generation settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct ImagesConfig {
+    /// Pixel widths (longer edge) to generate for responsive `<picture>`
+    /// elements.
+    #[config(default = [800, 1400, 2080])]
+    pub sizes: Vec<u32>,
+    /// AVIF encoding quality (0 = worst, 100 = best).
+    #[config(default = 90)]
+    pub quality: u32,
+}
+
+// =============================================================================
+// Theme — mat_x and mat_y are split into distinct types so each side has
+// its own confique-declared defaults (and shows up correctly in the schema).
+// =============================================================================
+
+/// Horizontal mat around images, expressed as `clamp(min, size, max)`.
+///
+/// - `size`: preferred/fluid value, typically viewport-relative (e.g. `3vw`)
+/// - `min`: minimum bound (e.g. `1rem`)
+/// - `max`: maximum bound (e.g. `2.5rem`)
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct MatX {
+    /// Preferred/fluid value, typically viewport-relative.
+    #[config(default = "3vw")]
+    pub size: String,
+    /// Minimum bound.
+    #[config(default = "1rem")]
+    pub min: String,
+    /// Maximum bound.
+    #[config(default = "2.5rem")]
+    pub max: String,
+}
+
+/// Vertical mat around images, expressed as `clamp(min, size, max)`.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct MatY {
+    /// Preferred/fluid value, typically viewport-relative.
+    #[config(default = "6vw")]
+    pub size: String,
+    /// Minimum bound.
+    #[config(default = "2rem")]
+    pub min: String,
+    /// Maximum bound.
+    #[config(default = "5rem")]
+    pub max: String,
+}
+
+/// Render a `clamp(min, size, max)` CSS expression from the three parts.
+fn clamp_to_css(size: &str, min: &str, max: &str) -> String {
+    format!("clamp({}, {}, {})", min, size, max)
+}
+
+impl MatX {
+    pub fn to_css(&self) -> String {
+        clamp_to_css(&self.size, &self.min, &self.max)
     }
 }
 
-/// Parallel processing settings.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ProcessingConfig {
-    /// Maximum number of parallel image processing workers.
-    /// When absent or null, defaults to the number of CPU cores.
-    /// Values larger than the core count are clamped down.
-    pub max_processes: Option<usize>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialProcessingConfig {
-    pub max_processes: Option<usize>,
-}
-
-impl ProcessingConfig {
-    pub fn merge(mut self, other: PartialProcessingConfig) -> Self {
-        if other.max_processes.is_some() {
-            self.max_processes = other.max_processes;
-        }
-        self
+impl MatY {
+    pub fn to_css(&self) -> String {
+        clamp_to_css(&self.size, &self.min, &self.max)
     }
 }
+
+/// Theme / layout settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct ThemeConfig {
+    /// Horizontal mat around images. See `docs/dev/photo-page-layout.md`.
+    #[config(nested)]
+    pub mat_x: MatX,
+    /// Vertical mat around images. See `docs/dev/photo-page-layout.md`.
+    #[config(nested)]
+    pub mat_y: MatY,
+    /// Gap between thumbnails in both album and image grids (CSS value).
+    #[config(default = "0.2rem")]
+    pub thumbnail_gap: String,
+    /// Padding around the thumbnail grid container (CSS value).
+    #[config(default = "2rem")]
+    pub grid_padding: String,
+}
+
+// =============================================================================
+// Colors — light and dark are split into distinct types so each side has
+// its own confique-declared defaults.
+// =============================================================================
+
+/// Color configuration for light and dark modes.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct ColorConfig {
+    /// Light mode color scheme.
+    #[config(nested)]
+    pub light: LightColors,
+    /// Dark mode color scheme.
+    #[config(nested)]
+    pub dark: DarkColors,
+}
+
+/// Light-mode color scheme.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct LightColors {
+    /// Background color.
+    #[config(default = "#ffffff")]
+    pub background: String,
+    /// Primary text color.
+    #[config(default = "#111111")]
+    pub text: String,
+    /// Muted/secondary text color (nav menu, breadcrumbs, captions).
+    #[config(default = "#666666")]
+    pub text_muted: String,
+    /// Border color.
+    #[config(default = "#e0e0e0")]
+    pub border: String,
+    /// Separator color (header bar underline, nav menu divider).
+    #[config(default = "#e0e0e0")]
+    pub separator: String,
+    /// Link color.
+    #[config(default = "#333333")]
+    pub link: String,
+    /// Link hover color.
+    #[config(default = "#000000")]
+    pub link_hover: String,
+}
+
+/// Dark-mode color scheme.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct DarkColors {
+    /// Background color.
+    #[config(default = "#000000")]
+    pub background: String,
+    /// Primary text color.
+    #[config(default = "#fafafa")]
+    pub text: String,
+    /// Muted/secondary text color (nav menu, breadcrumbs, captions).
+    #[config(default = "#999999")]
+    pub text_muted: String,
+    /// Border color.
+    #[config(default = "#333333")]
+    pub border: String,
+    /// Separator color (header bar underline, nav menu divider).
+    #[config(default = "#333333")]
+    pub separator: String,
+    /// Link color.
+    #[config(default = "#cccccc")]
+    pub link: String,
+    /// Link hover color.
+    #[config(default = "#ffffff")]
+    pub link_hover: String,
+}
+
+// =============================================================================
+// Font
+// =============================================================================
 
 /// Font category — determines fallback fonts in the CSS font stack.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -329,8 +488,8 @@ pub enum FontType {
 /// Font configuration for the site.
 ///
 /// By default, the font is loaded from Google Fonts via a `<link>` tag.
-/// Set `source` to a local font file path (relative to site root) to use
-/// a self-hosted font instead — this generates a `@font-face` declaration
+/// Set `source` to a local font file path (relative to site root) to use a
+/// self-hosted font instead — this generates a `@font-face` declaration
 /// and skips the Google Fonts request entirely.
 ///
 /// ```toml
@@ -347,59 +506,27 @@ pub enum FontType {
 /// font_type = "sans"
 /// source = "fonts/MyFont.woff2"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
 pub struct FontConfig {
     /// Font family name (Google Fonts family or custom name for local fonts).
+    #[config(default = "Noto Sans")]
     pub font: String,
     /// Font weight to load (e.g. `"600"`).
+    #[config(default = "600")]
     pub weight: String,
     /// Font category: `"sans"` or `"serif"` — determines fallback fonts.
+    #[config(default = "sans")]
     pub font_type: FontType,
-    /// Path to a local font file, relative to the site root (e.g. `"fonts/MyFont.woff2"`).
-    /// When set, generates `@font-face` CSS instead of loading from Google Fonts.
-    /// The file should be placed in the assets directory so it gets copied to the output.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Path to a local font file, relative to the site root
+    /// (e.g. `"fonts/MyFont.woff2"`). When set, generates `@font-face` CSS
+    /// instead of loading from Google Fonts. The file should be placed in
+    /// the assets directory so it gets copied to the output.
     pub source: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialFontConfig {
-    pub font: Option<String>,
-    pub weight: Option<String>,
-    pub font_type: Option<FontType>,
-    pub source: Option<String>,
-}
-
-impl Default for FontConfig {
-    fn default() -> Self {
-        Self {
-            font: "Noto Sans".to_string(),
-            weight: "600".to_string(),
-            font_type: FontType::Sans,
-            source: None,
-        }
-    }
 }
 
 impl FontConfig {
-    pub fn merge(mut self, other: PartialFontConfig) -> Self {
-        if let Some(f) = other.font {
-            self.font = f;
-        }
-        if let Some(w) = other.weight {
-            self.weight = w;
-        }
-        if let Some(t) = other.font_type {
-            self.font_type = t;
-        }
-        if other.source.is_some() {
-            self.source = other.source;
-        }
-        self
-    }
-
     /// Whether this font is loaded from a local file (vs. Google Fonts).
     pub fn is_local(&self) -> bool {
         self.source.is_some()
@@ -418,8 +545,8 @@ impl FontConfig {
         ))
     }
 
-    /// Generate `@font-face` CSS for a local font.
-    /// Returns `None` for Google Fonts.
+    /// Generate `@font-face` CSS for a local font. Returns `None` for
+    /// Google Fonts.
     pub fn font_face_css(&self) -> Option<String> {
         let src = self.source.as_ref()?;
         let format = font_format_from_extension(src);
@@ -455,6 +582,21 @@ fn font_format_from_extension(path: &str) -> &'static str {
     }
 }
 
+// =============================================================================
+// Processing
+// =============================================================================
+
+/// Parallel processing settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[config(layer_attr(derive(Clone)))]
+#[config(layer_attr(serde(deny_unknown_fields)))]
+pub struct ProcessingConfig {
+    /// Maximum number of parallel image processing workers.
+    /// When absent, defaults to the number of CPU cores.
+    /// Values larger than the core count are clamped down.
+    pub max_processes: Option<usize>,
+}
+
 /// Resolve the effective thread count from config.
 ///
 /// - `None` → use all available cores
@@ -466,584 +608,78 @@ pub fn effective_threads(config: &ProcessingConfig) -> usize {
     config.max_processes.map(|n| n.min(cores)).unwrap_or(cores)
 }
 
-/// Thumbnail generation settings.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ThumbnailsConfig {
-    /// Aspect ratio as `[width, height]`, e.g. `[4, 5]` for portrait thumbnails.
-    pub aspect_ratio: [u32; 2],
-    /// Thumbnail short-edge size in pixels.
-    pub size: u32,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialThumbnailsConfig {
-    pub aspect_ratio: Option<[u32; 2]>,
-    pub size: Option<u32>,
-}
-
-impl ThumbnailsConfig {
-    pub fn merge(mut self, other: PartialThumbnailsConfig) -> Self {
-        if let Some(ar) = other.aspect_ratio {
-            self.aspect_ratio = ar;
-        }
-        if let Some(s) = other.size {
-            self.size = s;
-        }
-        self
-    }
-}
-
-impl Default for ThumbnailsConfig {
-    fn default() -> Self {
-        Self {
-            aspect_ratio: [4, 5],
-            size: 400,
-        }
-    }
-}
-
-/// Settings for the site-wide "All Photos" index page.
-///
-/// When `generates` is true, the generate stage renders an extra page at
-/// `/all-photos/` showing every image from every public album in a single
-/// thumbnail grid. Thumbnails are generated at the ratio/size specified here,
-/// independent of the regular per-album `[thumbnails]` settings.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct FullIndexConfig {
-    /// Whether the All Photos page is rendered.
-    pub generates: bool,
-    /// Whether to add an "All Photos" item to the navigation menu.
-    pub show_link: bool,
-    /// Aspect ratio `[width, height]` for full-index thumbnails.
-    pub thumb_ratio: [u32; 2],
-    /// Short-edge size (in pixels) for full-index thumbnails.
-    pub thumb_size: u32,
-    /// Gap between thumbnails on the All Photos grid (CSS value).
-    pub thumb_gap: String,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialFullIndexConfig {
-    pub generates: Option<bool>,
-    pub show_link: Option<bool>,
-    pub thumb_ratio: Option<[u32; 2]>,
-    pub thumb_size: Option<u32>,
-    pub thumb_gap: Option<String>,
-}
-
-impl FullIndexConfig {
-    pub fn merge(mut self, other: PartialFullIndexConfig) -> Self {
-        if let Some(g) = other.generates {
-            self.generates = g;
-        }
-        if let Some(l) = other.show_link {
-            self.show_link = l;
-        }
-        if let Some(r) = other.thumb_ratio {
-            self.thumb_ratio = r;
-        }
-        if let Some(s) = other.thumb_size {
-            self.thumb_size = s;
-        }
-        if let Some(g) = other.thumb_gap {
-            self.thumb_gap = g;
-        }
-        self
-    }
-}
-
-impl Default for FullIndexConfig {
-    fn default() -> Self {
-        Self {
-            generates: false,
-            show_link: false,
-            thumb_ratio: [4, 5],
-            thumb_size: 400,
-            thumb_gap: "0.2rem".to_string(),
-        }
-    }
-}
-
-/// Responsive image generation settings.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ImagesConfig {
-    /// Pixel widths (longer edge) to generate for responsive `<picture>` elements.
-    pub sizes: Vec<u32>,
-    /// AVIF encoding quality (0 = worst, 100 = best).
-    pub quality: u32,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialImagesConfig {
-    pub sizes: Option<Vec<u32>>,
-    pub quality: Option<u32>,
-}
-
-impl ImagesConfig {
-    pub fn merge(mut self, other: PartialImagesConfig) -> Self {
-        if let Some(s) = other.sizes {
-            self.sizes = s;
-        }
-        if let Some(q) = other.quality {
-            self.quality = q;
-        }
-        self
-    }
-}
-
-impl Default for ImagesConfig {
-    fn default() -> Self {
-        Self {
-            sizes: vec![800, 1400, 2080],
-            quality: 90,
-        }
-    }
-}
-
-/// A responsive CSS size expressed as `clamp(min, size, max)`.
-///
-/// - `size`: the preferred/fluid value, typically viewport-relative (e.g. `"3vw"`)
-/// - `min`: the minimum bound (e.g. `"1rem"`)
-/// - `max`: the maximum bound (e.g. `"2.5rem"`)
-///
-/// Generates `clamp(min, size, max)` in the output CSS.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct ClampSize {
-    /// Preferred/fluid value, typically viewport-relative (e.g. `"3vw"`).
-    pub size: String,
-    /// Minimum bound (e.g. `"1rem"`).
-    pub min: String,
-    /// Maximum bound (e.g. `"2.5rem"`).
-    pub max: String,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialClampSize {
-    pub size: Option<String>,
-    pub min: Option<String>,
-    pub max: Option<String>,
-}
-
-impl ClampSize {
-    pub fn merge(mut self, other: PartialClampSize) -> Self {
-        if let Some(s) = other.size {
-            self.size = s;
-        }
-        if let Some(m) = other.min {
-            self.min = m;
-        }
-        if let Some(m) = other.max {
-            self.max = m;
-        }
-        self
-    }
-}
-
-impl ClampSize {
-    /// Render as a CSS `clamp()` expression.
-    pub fn to_css(&self) -> String {
-        format!("clamp({}, {}, {})", self.min, self.size, self.max)
-    }
-}
-
-/// Theme/layout settings.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ThemeConfig {
-    /// Horizontal mat around images (left/right). See docs/dev/photo-page-layout.md.
-    pub mat_x: ClampSize,
-    /// Vertical mat around images (top/bottom). See docs/dev/photo-page-layout.md.
-    pub mat_y: ClampSize,
-    /// Gap between thumbnails in both album and image grids (CSS value).
-    pub thumbnail_gap: String,
-    /// Padding around the thumbnail grid container (CSS value).
-    pub grid_padding: String,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialThemeConfig {
-    pub mat_x: Option<PartialClampSize>,
-    pub mat_y: Option<PartialClampSize>,
-    pub thumbnail_gap: Option<String>,
-    pub grid_padding: Option<String>,
-}
-
-impl ThemeConfig {
-    pub fn merge(mut self, other: PartialThemeConfig) -> Self {
-        if let Some(x) = other.mat_x {
-            self.mat_x = self.mat_x.merge(x);
-        }
-        if let Some(y) = other.mat_y {
-            self.mat_y = self.mat_y.merge(y);
-        }
-        if let Some(g) = other.thumbnail_gap {
-            self.thumbnail_gap = g;
-        }
-        if let Some(p) = other.grid_padding {
-            self.grid_padding = p;
-        }
-        self
-    }
-}
-
-impl Default for ThemeConfig {
-    fn default() -> Self {
-        Self {
-            mat_x: ClampSize {
-                size: "3vw".to_string(),
-                min: "1rem".to_string(),
-                max: "2.5rem".to_string(),
-            },
-            mat_y: ClampSize {
-                size: "6vw".to_string(),
-                min: "2rem".to_string(),
-                max: "5rem".to_string(),
-            },
-            thumbnail_gap: "0.2rem".to_string(),
-            grid_padding: "2rem".to_string(),
-        }
-    }
-}
-
-/// Color configuration for light and dark modes.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ColorConfig {
-    /// Light mode color scheme.
-    pub light: ColorScheme,
-    /// Dark mode color scheme.
-    pub dark: ColorScheme,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialColorConfig {
-    pub light: Option<PartialColorScheme>,
-    pub dark: Option<PartialColorScheme>,
-}
-
-impl ColorConfig {
-    pub fn merge(mut self, other: PartialColorConfig) -> Self {
-        if let Some(l) = other.light {
-            self.light = self.light.merge(l);
-        }
-        if let Some(d) = other.dark {
-            self.dark = self.dark.merge(d);
-        }
-        self
-    }
-}
-
-impl Default for ColorConfig {
-    fn default() -> Self {
-        Self {
-            light: ColorScheme::default_light(),
-            dark: ColorScheme::default_dark(),
-        }
-    }
-}
-
-/// Individual color scheme (light or dark).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
-pub struct ColorScheme {
-    /// Background color.
-    pub background: String,
-    /// Primary text color.
-    pub text: String,
-    /// Muted/secondary text color (used for nav menu, breadcrumbs, captions).
-    pub text_muted: String,
-    /// Border color.
-    pub border: String,
-    /// Separator color (header bar underline, nav menu divider).
-    pub separator: String,
-    /// Link color.
-    pub link: String,
-    /// Link hover color.
-    pub link_hover: String,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PartialColorScheme {
-    pub background: Option<String>,
-    pub text: Option<String>,
-    pub text_muted: Option<String>,
-    pub border: Option<String>,
-    pub separator: Option<String>,
-    pub link: Option<String>,
-    pub link_hover: Option<String>,
-}
-
-impl ColorScheme {
-    pub fn merge(mut self, other: PartialColorScheme) -> Self {
-        if let Some(v) = other.background {
-            self.background = v;
-        }
-        if let Some(v) = other.text {
-            self.text = v;
-        }
-        if let Some(v) = other.text_muted {
-            self.text_muted = v;
-        }
-        if let Some(v) = other.border {
-            self.border = v;
-        }
-        if let Some(v) = other.separator {
-            self.separator = v;
-        }
-        if let Some(v) = other.link {
-            self.link = v;
-        }
-        if let Some(v) = other.link_hover {
-            self.link_hover = v;
-        }
-        self
-    }
-}
-
-impl ColorScheme {
-    pub fn default_light() -> Self {
-        Self {
-            background: "#ffffff".to_string(),
-            text: "#111111".to_string(),
-            text_muted: "#666666".to_string(),
-            border: "#e0e0e0".to_string(),
-            separator: "#e0e0e0".to_string(),
-            link: "#333333".to_string(),
-            link_hover: "#000000".to_string(),
-        }
-    }
-
-    pub fn default_dark() -> Self {
-        Self {
-            background: "#000000".to_string(),
-            text: "#fafafa".to_string(),
-            text_muted: "#999999".to_string(),
-            border: "#333333".to_string(),
-            separator: "#333333".to_string(),
-            link: "#cccccc".to_string(),
-            link_hover: "#ffffff".to_string(),
-        }
-    }
-}
-
-impl Default for ColorScheme {
-    fn default() -> Self {
-        Self::default_light()
-    }
-}
-
 // =============================================================================
-// Config loading, merging, and validation
+// Loading: per-file partial layer + per-directory cascade helpers
 // =============================================================================
 
-/// Load a partial, validated config from `config.toml`.
+/// Confique-derived layer type for `SiteConfig`.
 ///
-/// Returns `Ok(None)` if no `config.toml` exists.
-/// Returns `Err` if the file exists but contains unknown keys or invalid values.
-pub fn load_partial_config(path: &Path) -> Result<Option<PartialSiteConfig>, ConfigError> {
-    let config_path = path.join("config.toml");
+/// Every field is `Option<T>` so layers compose by overlay. The scan stage
+/// produces one of these per `config.toml` it finds and folds them together
+/// with [`with_fallback`][confique::Layer::with_fallback].
+pub type SiteConfigLayer = <SiteConfig as Config>::Layer;
+
+/// Load a single sparse `config.toml` from `dir` into a layer.
+///
+/// Returns `Ok(None)` if the file is absent — caller decides whether that's
+/// an error. Returns `Err` for parse failures (with the original text
+/// retained for snippet rendering) and for unknown-key violations enforced
+/// by confique's strict deserializer.
+pub fn load_layer(dir: &Path) -> Result<Option<SiteConfigLayer>, ConfigError> {
+    let config_path = dir.join("config.toml");
     if !config_path.exists() {
         return Ok(None);
     }
     let content = fs::read_to_string(&config_path)?;
-    let partial: PartialSiteConfig = toml::from_str(&content).map_err(|e| ConfigError::Toml {
+    let layer: SiteConfigLayer = toml::from_str(&content).map_err(|e| ConfigError::Toml {
         path: config_path.clone(),
         source: Box::new(e),
         source_text: content,
     })?;
-    Ok(Some(partial))
+    Ok(Some(layer))
 }
 
-/// Load config from `config.toml` in the given directory and merge onto defaults.
-pub fn load_config(root: &Path) -> Result<SiteConfig, ConfigError> {
-    let base = SiteConfig::default();
-    let partial = load_partial_config(root)?;
-    if let Some(p) = partial {
-        let merged = base.merge(p);
-        merged.validate()?;
-        Ok(merged)
-    } else {
-        Ok(base)
-    }
-}
-
-/// Returns a fully-commented stock `config.toml` with all keys and explanations.
+/// Load `config.toml` from `dir`, merge it onto confique defaults, and
+/// validate.
 ///
-/// Used by the `gen-config` CLI command.
-pub fn stock_config_toml() -> &'static str {
-    r##"# Simple Gal Configuration
-# ========================
-# All settings are optional. Remove or comment out any you don't need.
-# Values shown below are the defaults.
-#
-# Config files can be placed at any level of the directory tree:
-#   content/config.toml          -> root (overrides stock defaults)
-#   content/020-Travel/config.toml -> group (overrides root)
-#   content/020-Travel/010-Japan/config.toml -> gallery (overrides group)
-#
-# Each level only needs the keys it wants to override.
-# Unknown keys will cause an error.
-
-# Site title shown in breadcrumbs and the browser tab for the home page.
-site_title = "Gallery"
-
-# Directory for static assets (favicon, fonts, etc.), relative to content root.
-# Contents are copied verbatim to the output root during generation.
-# If the directory doesn't exist, it is silently skipped.
-assets_dir = "assets"
-
-# Stem of the site description file in the content root.
-# If site.md or site.txt exists, its content is rendered on the index page.
-# site_description_file = "site"
-
-# ---------------------------------------------------------------------------
-# Thumbnail generation
-# ---------------------------------------------------------------------------
-[thumbnails]
-# Aspect ratio as [width, height] for thumbnail crops.
-# Common choices: [1, 1] for square, [4, 5] for portrait, [3, 2] for landscape.
-aspect_ratio = [4, 5]
-
-# Short-edge size in pixels for generated thumbnails.
-size = 400
-
-# ---------------------------------------------------------------------------
-# Full index ("All Photos") page
-# ---------------------------------------------------------------------------
-# When enabled, generates a single page at /all-photos/ showing every image
-# from every public album in one thumbnail grid. Off by default.
-[full_index]
-# If true, renders the All Photos page.
-generates = false
-
-# If true, adds an "All Photos" entry to the navigation menu.
-show_link = false
-
-# Aspect ratio [width, height] for full-index thumbnails.
-thumb_ratio = [4, 5]
-
-# Short-edge size in pixels for full-index thumbnails.
-thumb_size = 400
-
-# Gap between thumbnails on the All Photos grid (CSS value).
-thumb_gap = "0.2rem"
-
-# ---------------------------------------------------------------------------
-# Responsive image generation
-# ---------------------------------------------------------------------------
-[images]
-# Pixel widths (longer edge) to generate for responsive <picture> elements.
-sizes = [800, 1400, 2080]
-
-# AVIF encoding quality (0 = worst, 100 = best).
-quality = 90
-
-# ---------------------------------------------------------------------------
-# Theme / layout
-# ---------------------------------------------------------------------------
-[theme]
-# Gap between thumbnails in album and image grids (CSS value).
-thumbnail_gap = "0.2rem"
-
-# Padding around the thumbnail grid container (CSS value).
-grid_padding = "2rem"
-
-# Horizontal mat around images, as CSS clamp(min, size, max).
-# See docs/dev/photo-page-layout.md for the layout spec.
-[theme.mat_x]
-size = "3vw"
-min = "1rem"
-max = "2.5rem"
-
-# Vertical mat around images, as CSS clamp(min, size, max).
-[theme.mat_y]
-size = "6vw"
-min = "2rem"
-max = "5rem"
-
-# ---------------------------------------------------------------------------
-# Colors - Light mode (prefers-color-scheme: light)
-# ---------------------------------------------------------------------------
-[colors.light]
-background = "#ffffff"
-text = "#111111"
-text_muted = "#666666"    # Nav, breadcrumbs, captions
-border = "#e0e0e0"
-separator = "#e0e0e0"     # Header underline, nav menu divider
-link = "#333333"
-link_hover = "#000000"
-
-# ---------------------------------------------------------------------------
-# Colors - Dark mode (prefers-color-scheme: dark)
-# ---------------------------------------------------------------------------
-[colors.dark]
-background = "#000000"
-text = "#fafafa"
-text_muted = "#999999"
-border = "#333333"
-separator = "#333333"     # Header underline, nav menu divider
-link = "#cccccc"
-link_hover = "#ffffff"
-
-# ---------------------------------------------------------------------------
-# Font
-# ---------------------------------------------------------------------------
-[font]
-# Google Fonts family name.
-font = "Noto Sans"
-
-# Font weight to load from Google Fonts.
-weight = "600"
-
-# Font category: "sans" or "serif". Determines fallback fonts in the CSS stack.
-# sans  -> Helvetica, Verdana, sans-serif
-# serif -> Georgia, "Times New Roman", serif
-font_type = "sans"
-
-# Local font file path, relative to the site root (e.g. "fonts/MyFont.woff2").
-# When set, generates @font-face CSS instead of loading from Google Fonts.
-# Place the font file in your assets directory so it gets copied to the output.
-# Supported formats: .woff2, .woff, .ttf, .otf
-# source = "fonts/MyFont.woff2"
-
-# ---------------------------------------------------------------------------
-# Processing
-# ---------------------------------------------------------------------------
-[processing]
-# Maximum parallel image-processing workers.
-# Omit or comment out to auto-detect (= number of CPU cores).
-# max_processes = 4
-
-# ---------------------------------------------------------------------------
-# Custom CSS & HTML Snippets
-# ---------------------------------------------------------------------------
-# Drop any of these files into your assets/ directory to inject custom content.
-# No configuration needed — the files are detected automatically.
-#
-#   assets/custom.css    → <link rel="stylesheet"> after main styles (CSS overrides)
-#   assets/head.html     → raw HTML at the end of <head> (analytics, meta tags)
-#   assets/body-end.html → raw HTML before </body> (tracking scripts, widgets)
-"##
+/// Used at the root of the cascade and by tests that exercise the full
+/// load → validate flow.
+pub fn load_config(dir: &Path) -> Result<SiteConfig, ConfigError> {
+    let user = load_layer(dir)?.unwrap_or_else(SiteConfigLayer::empty);
+    let merged = user.with_fallback(SiteConfigLayer::default_values());
+    let config = SiteConfig::from_layer(merged)?;
+    config.validate()?;
+    Ok(config)
 }
+
+/// Build a `SiteConfig` from a single layer, merging in confique defaults
+/// for any unset fields. Validates before returning. Used by the scan
+/// stage's per-directory cascade after layers have been folded together.
+pub fn finalize_layer(layer: SiteConfigLayer) -> Result<SiteConfig, ConfigError> {
+    let merged = layer.with_fallback(SiteConfigLayer::default_values());
+    let config = SiteConfig::from_layer(merged)?;
+    config.validate()?;
+    Ok(config)
+}
+
+/// Static metadata for the `SiteConfig` schema. Re-exported so the
+/// [`crate`] CLI can hand it to clapfig's schema-emitting subcommand
+/// without having to depend on confique itself.
+pub fn site_config_meta() -> &'static Meta {
+    &<SiteConfig as Config>::META
+}
+
+// =============================================================================
+// CSS generators (consumers of resolved config — not config plumbing)
+// =============================================================================
 
 /// Generate CSS custom properties from color config.
 ///
 /// These `generate_*_css()` functions produce `:root { … }` blocks that are
-/// prepended to the inline `<style>` in every page. The Google Font is loaded
-/// separately via a `<link>` tag (see `FontConfig::stylesheet_url` and
-/// `base_document` in generate.rs). Variables defined here are consumed by
-/// `static/style.css`; do not redefine them there.
+/// prepended to the inline `<style>` in every page. The Google Font is
+/// loaded separately via a `<link>` tag (see `FontConfig::stylesheet_url`
+/// and `base_document` in `generate.rs`). Variables defined here are
+/// consumed by `static/style.css`; do not redefine them there.
 pub fn generate_color_css(colors: &ColorConfig) -> String {
     format!(
         r#":root {{
@@ -1123,6 +759,12 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn write_config(dir: &Path, body: &str) {
+        fs::write(dir.join("config.toml"), body).unwrap();
+    }
+
+    // ----- defaults -----
+
     #[test]
     fn default_config_has_colors() {
         let config = SiteConfig::default();
@@ -1137,14 +779,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_custom_site_title() {
-        let toml = r#"site_title = "My Portfolio""#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.site_title, "My Portfolio");
-    }
-
-    #[test]
     fn default_config_has_image_settings() {
         let config = SiteConfig::default();
         assert_eq!(config.thumbnails.aspect_ratio, [4, 5]);
@@ -1155,53 +789,283 @@ mod tests {
     }
 
     #[test]
-    fn parse_partial_config() {
-        let toml = r##"
+    fn default_full_index_is_off() {
+        let config = SiteConfig::default();
+        assert!(!config.full_index.generates);
+        assert!(!config.full_index.show_link);
+        assert_eq!(config.full_index.thumb_ratio, [4, 5]);
+        assert_eq!(config.full_index.thumb_size, 400);
+        assert_eq!(config.full_index.thumb_gap, "0.2rem");
+    }
+
+    #[test]
+    fn default_thumbnail_gap_and_grid_padding() {
+        let config = SiteConfig::default();
+        assert_eq!(config.theme.thumbnail_gap, "0.2rem");
+        assert_eq!(config.theme.grid_padding, "2rem");
+    }
+
+    #[test]
+    fn default_assets_dir() {
+        let config = SiteConfig::default();
+        assert_eq!(config.assets_dir, "assets");
+    }
+
+    #[test]
+    fn default_site_description_file() {
+        let config = SiteConfig::default();
+        assert_eq!(config.site_description_file, "site");
+    }
+
+    #[test]
+    fn default_processing_config() {
+        let config = SiteConfig::default();
+        assert_eq!(config.processing.max_processes, None);
+    }
+
+    // ----- sparse layer parsing through load_config -----
+
+    #[test]
+    fn parse_custom_site_title() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), r#"site_title = "My Portfolio""#);
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.site_title, "My Portfolio");
+    }
+
+    #[test]
+    fn parse_partial_colors_only() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
 [colors.light]
 background = "#fafafa"
-"##;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
         // Overridden value
         assert_eq!(config.colors.light.background, "#fafafa");
-        // Default values preserved
+        // Sibling defaults preserved
         assert_eq!(config.colors.light.text, "#111111");
         assert_eq!(config.colors.dark.background, "#000000");
-        // Image settings should be defaults
+        // Unrelated section defaults preserved
         assert_eq!(config.images.sizes, vec![800, 1400, 2080]);
     }
 
     #[test]
     fn parse_image_settings() {
-        let toml = r##"
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
 [thumbnails]
 aspect_ratio = [1, 1]
 
 [images]
 sizes = [400, 800]
 quality = 85
-"##;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
         assert_eq!(config.thumbnails.aspect_ratio, [1, 1]);
         assert_eq!(config.images.sizes, vec![400, 800]);
         assert_eq!(config.images.quality, 85);
-        // Unspecified defaults preserved
         assert_eq!(config.colors.light.background, "#ffffff");
     }
+
+    #[test]
+    fn parse_full_index_settings() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[full_index]
+generates = true
+show_link = true
+thumb_ratio = [4, 4]
+thumb_size = 1000
+thumb_gap = "0.5rem"
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert!(config.full_index.generates);
+        assert!(config.full_index.show_link);
+        assert_eq!(config.full_index.thumb_ratio, [4, 4]);
+        assert_eq!(config.full_index.thumb_size, 1000);
+        assert_eq!(config.full_index.thumb_gap, "0.5rem");
+    }
+
+    #[test]
+    fn full_index_partial_preserves_defaults() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[full_index]
+generates = true
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert!(config.full_index.generates);
+        assert!(!config.full_index.show_link);
+        assert_eq!(config.full_index.thumb_ratio, [4, 5]);
+        assert_eq!(config.full_index.thumb_size, 400);
+    }
+
+    #[test]
+    fn parse_partial_theme_mat_x_only() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r#"
+[theme.mat_x]
+size = "5vw"
+"#,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        // Overridden
+        assert_eq!(config.theme.mat_x.size, "5vw");
+        // Preserved from defaults
+        assert_eq!(config.theme.mat_x.min, "1rem");
+        assert_eq!(config.theme.mat_x.max, "2.5rem");
+        // mat_y entirely untouched
+        assert_eq!(config.theme.mat_y.size, "6vw");
+        assert_eq!(config.theme.mat_y.min, "2rem");
+        assert_eq!(config.theme.mat_y.max, "5rem");
+        // Other theme fields untouched
+        assert_eq!(config.theme.thumbnail_gap, "0.2rem");
+        assert_eq!(config.theme.grid_padding, "2rem");
+    }
+
+    #[test]
+    fn parse_partial_colors_light_keeps_dark_defaults() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[colors.light]
+background = "#fafafa"
+text = "#222222"
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.colors.light.background, "#fafafa");
+        assert_eq!(config.colors.light.text, "#222222");
+        // Light defaults preserved for unset fields
+        assert_eq!(config.colors.light.text_muted, "#666666");
+        assert_eq!(config.colors.light.border, "#e0e0e0");
+        assert_eq!(config.colors.light.link, "#333333");
+        assert_eq!(config.colors.light.link_hover, "#000000");
+        // Dark entirely untouched
+        assert_eq!(config.colors.dark.background, "#000000");
+        assert_eq!(config.colors.dark.text, "#fafafa");
+    }
+
+    #[test]
+    fn parse_partial_font_weight_only() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r#"
+[font]
+weight = "300"
+"#,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.font.weight, "300");
+        assert_eq!(config.font.font, "Noto Sans");
+        assert_eq!(config.font.font_type, FontType::Sans);
+    }
+
+    #[test]
+    fn parse_thumbnail_gap_and_grid_padding() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r#"
+[theme]
+thumbnail_gap = "0.5rem"
+grid_padding = "1rem"
+"#,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.theme.thumbnail_gap, "0.5rem");
+        assert_eq!(config.theme.grid_padding, "1rem");
+    }
+
+    #[test]
+    fn parse_processing_config() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), "[processing]\nmax_processes = 4\n");
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.processing.max_processes, Some(4));
+    }
+
+    #[test]
+    fn parse_config_without_processing_uses_default() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[colors.light]
+background = "#fafafa"
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.processing.max_processes, None);
+    }
+
+    #[test]
+    fn parse_custom_assets_dir() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), r#"assets_dir = "site-assets""#);
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.assets_dir, "site-assets");
+    }
+
+    #[test]
+    fn parse_custom_site_description_file() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), r#"site_description_file = "intro""#);
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.site_description_file, "intro");
+    }
+
+    #[test]
+    fn parse_multiple_sections_independently() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[colors.dark]
+background = "#1a1a1a"
+
+[font]
+font = "Lora"
+font_type = "serif"
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.colors.dark.background, "#1a1a1a");
+        assert_eq!(config.colors.dark.text, "#fafafa");
+        assert_eq!(config.colors.light.background, "#ffffff");
+        assert_eq!(config.font.font, "Lora");
+        assert_eq!(config.font.font_type, FontType::Serif);
+        assert_eq!(config.font.weight, "600");
+        assert_eq!(config.images.quality, 90);
+        assert_eq!(config.thumbnails.aspect_ratio, [4, 5]);
+        assert_eq!(config.theme.mat_x.size, "3vw");
+    }
+
+    // ----- error rendering -----
 
     #[test]
     fn toml_error_carries_path_and_source_text() {
         let tmp = TempDir::new().unwrap();
         // Unquoted CSS value — the same class of mistake that produced the
         // original "expected newline, `#`" error we want rich rendering for.
-        fs::write(
-            tmp.path().join("config.toml"),
-            "[theme]\nthumbnail_gap = 0.2rem\n",
-        )
-        .unwrap();
+        write_config(tmp.path(), "[theme]\nthumbnail_gap = 0.2rem\n");
         let err = load_config(tmp.path()).unwrap_err();
         match &err {
             ConfigError::Toml {
@@ -1220,18 +1084,11 @@ quality = 85
     #[test]
     fn to_clapfig_error_wraps_parse_failure() {
         let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("config.toml"),
-            "[theme]\nthumbnail_gap = 0.2rem\n",
-        )
-        .unwrap();
+        write_config(tmp.path(), "[theme]\nthumbnail_gap = 0.2rem\n");
         let err = load_config(tmp.path()).unwrap_err();
         let clap_err = err
             .to_clapfig_error()
             .expect("parse errors should be convertible to ClapfigError");
-
-        // Structural check: the data is populated — path, toml::de::Error,
-        // and the retained source text.
         let (path, parse_err, source_text) = clap_err
             .parse_error()
             .expect("ClapfigError should be a ParseError");
@@ -1248,18 +1105,11 @@ quality = 85
 
     #[test]
     fn clapfig_render_plain_includes_path_and_snippet() {
-        // End-to-end check that we can hand the error to clapfig's plain
-        // renderer and get back a snippet that points at the bad line.
         let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("config.toml"),
-            "[theme]\nthumbnail_gap = 0.2rem\n",
-        )
-        .unwrap();
+        write_config(tmp.path(), "[theme]\nthumbnail_gap = 0.2rem\n");
         let err = load_config(tmp.path()).unwrap_err();
         let clap_err = err.to_clapfig_error().unwrap();
         let out = clapfig::render::render_plain(&clap_err);
-
         assert!(out.contains("config.toml"), "missing path in {out}");
         assert!(
             out.contains("thumbnail_gap"),
@@ -1268,50 +1118,83 @@ quality = 85
         assert!(out.contains('^'), "missing caret in {out}");
     }
 
+    // ----- load_config behavior -----
+
     #[test]
-    fn default_full_index_is_off() {
-        let config = SiteConfig::default();
-        assert!(!config.full_index.generates);
-        assert!(!config.full_index.show_link);
-        assert_eq!(config.full_index.thumb_ratio, [4, 5]);
-        assert_eq!(config.full_index.thumb_size, 400);
-        assert_eq!(config.full_index.thumb_gap, "0.2rem");
+    fn load_config_returns_default_when_no_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.colors.light.background, "#ffffff");
+        assert_eq!(config.colors.dark.background, "#000000");
     }
 
     #[test]
-    fn parse_full_index_settings() {
-        let toml = r##"
-[full_index]
-generates = true
-show_link = true
-thumb_ratio = [4, 4]
-thumb_size = 1000
-thumb_gap = "0.5rem"
-"##;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-
-        assert!(config.full_index.generates);
-        assert!(config.full_index.show_link);
-        assert_eq!(config.full_index.thumb_ratio, [4, 4]);
-        assert_eq!(config.full_index.thumb_size, 1000);
-        assert_eq!(config.full_index.thumb_gap, "0.5rem");
+    fn load_config_reads_file() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r##"
+[colors.light]
+background = "#123456"
+text = "#abcdef"
+"##,
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.colors.light.background, "#123456");
+        assert_eq!(config.colors.light.text, "#abcdef");
+        assert_eq!(config.colors.dark.background, "#000000");
     }
 
     #[test]
-    fn full_index_partial_merge_preserves_defaults() {
-        let toml = r##"
-[full_index]
-generates = true
-"##;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
+    fn load_config_invalid_toml_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), "this is not valid toml [[[");
+        let result = load_config(tmp.path());
+        assert!(matches!(result, Err(ConfigError::Toml { .. })));
+    }
 
-        assert!(config.full_index.generates);
-        // Other fields keep defaults
-        assert!(!config.full_index.show_link);
-        assert_eq!(config.full_index.thumb_ratio, [4, 5]);
-        assert_eq!(config.full_index.thumb_size, 400);
+    #[test]
+    fn load_config_unknown_keys_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), "unknown_key = \"foo\"\n");
+        let result = load_config(tmp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_config_validates_values() {
+        let tmp = TempDir::new().unwrap();
+        write_config(tmp.path(), "[images]\nquality = 200\n");
+        let result = load_config(tmp.path());
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    // ----- validate() unit checks -----
+
+    #[test]
+    fn validate_quality_boundary_ok() {
+        let mut config = SiteConfig::default();
+        config.images.quality = 100;
+        assert!(config.validate().is_ok());
+        config.images.quality = 0;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_quality_too_high() {
+        let mut config = SiteConfig::default();
+        config.images.quality = 101;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("quality"));
+    }
+
+    #[test]
+    fn validate_aspect_ratio_zero() {
+        let mut config = SiteConfig::default();
+        config.thumbnails.aspect_ratio = [0, 5];
+        assert!(config.validate().is_err());
+        config.thumbnails.aspect_ratio = [4, 0];
+        assert!(config.validate().is_err());
     }
 
     #[test]
@@ -1322,201 +1205,19 @@ generates = true
     }
 
     #[test]
-    fn generate_css_uses_config_colors() {
-        let mut colors = ColorConfig::default();
-        colors.light.background = "#f0f0f0".to_string();
-        colors.dark.background = "#1a1a1a".to_string();
-
-        let css = generate_color_css(&colors);
-        assert!(css.contains("--color-bg: #f0f0f0"));
-        assert!(css.contains("--color-bg: #1a1a1a"));
-    }
-
-    // =========================================================================
-    // load_config tests
-    // =========================================================================
-
-    #[test]
-    fn load_config_returns_default_when_no_file() {
-        let tmp = TempDir::new().unwrap();
-        let config = load_config(tmp.path()).unwrap();
-
-        assert_eq!(config.colors.light.background, "#ffffff");
-        assert_eq!(config.colors.dark.background, "#000000");
+    fn validate_sizes_empty() {
+        let mut config = SiteConfig::default();
+        config.images.sizes = vec![];
+        assert!(config.validate().is_err());
     }
 
     #[test]
-    fn load_config_reads_file() {
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-
-        fs::write(
-            &config_path,
-            r##"
-[colors.light]
-background = "#123456"
-text = "#abcdef"
-"##,
-        )
-        .unwrap();
-
-        let config = load_config(tmp.path()).unwrap();
-        assert_eq!(config.colors.light.background, "#123456");
-        assert_eq!(config.colors.light.text, "#abcdef");
-        // Unspecified values should be defaults
-        assert_eq!(config.colors.dark.background, "#000000");
-    }
-
-    #[test]
-    fn load_config_full_config() {
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-
-        fs::write(
-            &config_path,
-            r##"
-[colors.light]
-background = "#fff"
-text = "#000"
-text_muted = "#666"
-border = "#ccc"
-link = "#00f"
-link_hover = "#f00"
-
-[colors.dark]
-background = "#111"
-text = "#eee"
-text_muted = "#888"
-border = "#444"
-link = "#88f"
-link_hover = "#f88"
-"##,
-        )
-        .unwrap();
-
-        let config = load_config(tmp.path()).unwrap();
-
-        // Light mode
-        assert_eq!(config.colors.light.background, "#fff");
-        assert_eq!(config.colors.light.text, "#000");
-        assert_eq!(config.colors.light.link, "#00f");
-
-        // Dark mode
-        assert_eq!(config.colors.dark.background, "#111");
-        assert_eq!(config.colors.dark.text, "#eee");
-        assert_eq!(config.colors.dark.link, "#88f");
-    }
-
-    #[test]
-    fn load_config_invalid_toml_is_error() {
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-
-        fs::write(&config_path, "this is not valid toml [[[").unwrap();
-
-        let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Toml { .. })));
-    }
-
-    #[test]
-    fn load_config_unknown_keys_is_error() {
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-
-        // "unknown_key" is not a valid field
-        fs::write(
-            &config_path,
-            r#"
-            unknown_key = "foo"
-            "#,
-        )
-        .unwrap();
-
-        let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Toml { .. })));
-    }
-
-    // =========================================================================
-    // CSS generation tests
-    // =========================================================================
-
-    #[test]
-    fn generate_css_includes_all_variables() {
-        let colors = ColorConfig::default();
-        let css = generate_color_css(&colors);
-
-        // Check all CSS variables are present
-        assert!(css.contains("--color-bg:"));
-        assert!(css.contains("--color-text:"));
-        assert!(css.contains("--color-text-muted:"));
-        assert!(css.contains("--color-border:"));
-        assert!(css.contains("--color-link:"));
-        assert!(css.contains("--color-link-hover:"));
-    }
-
-    #[test]
-    fn generate_css_includes_dark_mode_media_query() {
-        let colors = ColorConfig::default();
-        let css = generate_color_css(&colors);
-
-        assert!(css.contains("@media (prefers-color-scheme: dark)"));
-    }
-
-    #[test]
-    fn color_scheme_default_is_light() {
-        let scheme = ColorScheme::default();
-        assert_eq!(scheme.background, "#ffffff");
-    }
-
-    #[test]
-    fn clamp_size_to_css() {
-        let size = ClampSize {
-            size: "3vw".to_string(),
-            min: "1rem".to_string(),
-            max: "2.5rem".to_string(),
-        };
-        assert_eq!(size.to_css(), "clamp(1rem, 3vw, 2.5rem)");
-    }
-
-    #[test]
-    fn generate_theme_css_includes_mat_variables() {
-        let theme = ThemeConfig::default();
-        let css = generate_theme_css(&theme);
-        assert!(css.contains("--mat-x: clamp(1rem, 3vw, 2.5rem)"));
-        assert!(css.contains("--mat-y: clamp(2rem, 6vw, 5rem)"));
-        assert!(css.contains("--thumbnail-gap: 0.2rem"));
-        assert!(css.contains("--grid-padding: 2rem"));
-    }
-
-    #[test]
-    fn parse_thumbnail_gap_and_grid_padding() {
-        let toml = r#"
-[theme]
-thumbnail_gap = "0.5rem"
-grid_padding = "1rem"
-"#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.theme.thumbnail_gap, "0.5rem");
-        assert_eq!(config.theme.grid_padding, "1rem");
-    }
-
-    #[test]
-    fn default_thumbnail_gap_and_grid_padding() {
+    fn validate_default_config_passes() {
         let config = SiteConfig::default();
-        assert_eq!(config.theme.thumbnail_gap, "0.2rem");
-        assert_eq!(config.theme.grid_padding, "2rem");
+        assert!(config.validate().is_ok());
     }
 
-    // =========================================================================
-    // Processing config tests
-    // =========================================================================
-
-    #[test]
-    fn default_processing_config() {
-        let config = ProcessingConfig::default();
-        assert_eq!(config.max_processes, None);
-    }
+    // ----- effective_threads -----
 
     #[test]
     fn effective_threads_auto() {
@@ -1550,436 +1251,79 @@ grid_padding = "1rem"
         assert_eq!(effective_threads(&config), 1);
     }
 
-    #[test]
-    fn parse_processing_config() {
-        let toml = r#"
-[processing]
-max_processes = 4
-"#;
-        let config: SiteConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.processing.max_processes, Some(4));
-    }
+    // ----- CSS generation -----
 
     #[test]
-    fn parse_config_without_processing_uses_default() {
-        let toml = r##"
-[colors.light]
-background = "#fafafa"
-"##;
-        let config: SiteConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.processing.max_processes, None);
-    }
-
-    // =========================================================================
-    // merge_toml tests - REMOVED (function removed)
-    // =========================================================================
-
-    // =========================================================================
-    // Unknown key rejection tests
-    // =========================================================================
-
-    #[test]
-    fn unknown_key_rejected() {
-        let toml_str = r#"
-[images]
-qualty = 90
-"#;
-        let result: Result<SiteConfig, _> = toml::from_str(toml_str);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("unknown field"));
-    }
-
-    #[test]
-    fn unknown_section_rejected() {
-        let toml_str = r#"
-[imagez]
-quality = 90
-"#;
-        let result: Result<SiteConfig, _> = toml::from_str(toml_str);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn unknown_nested_key_rejected() {
-        let toml_str = r##"
-[colors.light]
-bg = "#fff"
-"##;
-        let result: Result<SiteConfig, _> = toml::from_str(toml_str);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn unknown_key_rejected_via_load_config() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("config.toml"),
-            r#"
-[images]
-qualty = 90
-"#,
-        )
-        .unwrap();
-
-        let result = load_config(tmp.path());
-        assert!(result.is_err());
-    }
-
-    // =========================================================================
-    // Validation tests
-    // =========================================================================
-
-    #[test]
-    fn validate_quality_boundary_ok() {
+    fn generate_css_uses_config_colors() {
         let mut config = SiteConfig::default();
-        config.images.quality = 100;
-        assert!(config.validate().is_ok());
-
-        config.images.quality = 0;
-        assert!(config.validate().is_ok());
+        config.colors.light.background = "#f0f0f0".to_string();
+        config.colors.dark.background = "#1a1a1a".to_string();
+        let css = generate_color_css(&config.colors);
+        assert!(css.contains("--color-bg: #f0f0f0"));
+        assert!(css.contains("--color-bg: #1a1a1a"));
     }
 
     #[test]
-    fn validate_quality_too_high() {
-        let mut config = SiteConfig::default();
-        config.images.quality = 101;
-        let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("quality"));
-    }
-
-    #[test]
-    fn validate_aspect_ratio_zero() {
-        let mut config = SiteConfig::default();
-        config.thumbnails.aspect_ratio = [0, 5];
-        assert!(config.validate().is_err());
-
-        config.thumbnails.aspect_ratio = [4, 0];
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn validate_sizes_empty() {
-        let mut config = SiteConfig::default();
-        config.images.sizes = vec![];
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn validate_default_config_passes() {
+    fn generate_css_includes_all_variables() {
         let config = SiteConfig::default();
-        assert!(config.validate().is_ok());
+        let css = generate_color_css(&config.colors);
+        assert!(css.contains("--color-bg:"));
+        assert!(css.contains("--color-text:"));
+        assert!(css.contains("--color-text-muted:"));
+        assert!(css.contains("--color-border:"));
+        assert!(css.contains("--color-link:"));
+        assert!(css.contains("--color-link-hover:"));
     }
 
     #[test]
-    fn load_config_validates_values() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("config.toml"),
-            r#"
-[images]
-quality = 200
-"#,
-        )
-        .unwrap();
-
-        let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Validation(_))));
-    }
-
-    // =========================================================================
-    // load_partial_config / merge tests
-    // =========================================================================
-
-    #[test]
-    fn load_partial_config_returns_none_when_no_file() {
-        let tmp = TempDir::new().unwrap();
-        let result = load_partial_config(tmp.path()).unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn load_partial_config_returns_value_when_file_exists() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("config.toml"),
-            r#"
-[images]
-quality = 85
-"#,
-        )
-        .unwrap();
-
-        let result = load_partial_config(tmp.path()).unwrap();
-        assert!(result.is_some());
-        let partial = result.unwrap();
-        assert_eq!(partial.images.unwrap().quality, Some(85));
-    }
-
-    #[test]
-    fn merge_with_no_overlay() {
-        let base = SiteConfig::default();
-        let config = base.merge(PartialSiteConfig::default());
-        assert_eq!(config.images.quality, 90);
-        assert_eq!(config.colors.light.background, "#ffffff");
-    }
-
-    #[test]
-    fn merge_with_overlay() {
-        let base = SiteConfig::default();
-        let toml = r#"
-[images]
-quality = 70
-"#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = base.merge(partial);
-        assert_eq!(config.images.quality, 70);
-        // Other fields preserved from defaults
-        assert_eq!(config.images.sizes, vec![800, 1400, 2080]);
-    }
-
-    #[test]
-    fn load_config_validates_after_merge() {
-        let tmp = TempDir::new().unwrap();
-        // Create config with invalid value
-        fs::write(
-            tmp.path().join("config.toml"),
-            r#"
-[images]
-quality = 200
-"#,
-        )
-        .unwrap();
-
-        // load_config should fail validation
-        let result = load_config(tmp.path());
-        assert!(matches!(result, Err(ConfigError::Validation(_))));
-    }
-
-    // =========================================================================
-    // stock_config_toml tests
-    // =========================================================================
-
-    #[test]
-    fn stock_config_toml_is_valid_toml() {
-        let content = stock_config_toml();
-        let _: toml::Value = toml::from_str(content).expect("stock config must be valid TOML");
-    }
-
-    #[test]
-    fn stock_config_toml_roundtrips_to_defaults() {
-        let content = stock_config_toml();
-        let config: SiteConfig = toml::from_str(content).unwrap();
-        assert_eq!(config.images.quality, 90);
-        assert_eq!(config.images.sizes, vec![800, 1400, 2080]);
-        assert_eq!(config.thumbnails.aspect_ratio, [4, 5]);
-        assert_eq!(config.colors.light.background, "#ffffff");
-        assert_eq!(config.colors.dark.background, "#000000");
-        assert_eq!(config.theme.thumbnail_gap, "0.2rem");
-    }
-
-    #[test]
-    fn stock_config_toml_contains_all_sections() {
-        let content = stock_config_toml();
-        assert!(content.contains("[thumbnails]"));
-        assert!(content.contains("[full_index]"));
-        assert!(content.contains("[images]"));
-        assert!(content.contains("[theme]"));
-        assert!(content.contains("[theme.mat_x]"));
-        assert!(content.contains("[theme.mat_y]"));
-        assert!(content.contains("[colors.light]"));
-        assert!(content.contains("[colors.dark]"));
-        assert!(content.contains("[processing]"));
-    }
-
-    #[test]
-    fn stock_defaults_equivalent_to_default_trait() {
-        // We removed stock_defaults_value, but we can test that Default trait works
+    fn generate_css_includes_dark_mode_media_query() {
         let config = SiteConfig::default();
-        assert_eq!(config.images.quality, 90);
-    }
-
-    // =========================================================================
-    // Partial nested merge tests — verify unset fields are preserved
-    // =========================================================================
-
-    #[test]
-    fn merge_partial_theme_mat_x_only() {
-        let partial: PartialSiteConfig = toml::from_str(
-            r#"
-            [theme.mat_x]
-            size = "5vw"
-        "#,
-        )
-        .unwrap();
-        let config = SiteConfig::default().merge(partial);
-
-        // Overridden
-        assert_eq!(config.theme.mat_x.size, "5vw");
-        // Preserved from defaults
-        assert_eq!(config.theme.mat_x.min, "1rem");
-        assert_eq!(config.theme.mat_x.max, "2.5rem");
-        // mat_y entirely untouched
-        assert_eq!(config.theme.mat_y.size, "6vw");
-        assert_eq!(config.theme.mat_y.min, "2rem");
-        assert_eq!(config.theme.mat_y.max, "5rem");
-        // Other theme fields untouched
-        assert_eq!(config.theme.thumbnail_gap, "0.2rem");
-        assert_eq!(config.theme.grid_padding, "2rem");
+        let css = generate_color_css(&config.colors);
+        assert!(css.contains("@media (prefers-color-scheme: dark)"));
     }
 
     #[test]
-    fn merge_partial_colors_light_only() {
-        let partial: PartialSiteConfig = toml::from_str(
-            r##"
-            [colors.light]
-            background = "#fafafa"
-            text = "#222222"
-        "##,
-        )
-        .unwrap();
-        let config = SiteConfig::default().merge(partial);
-
-        // Overridden
-        assert_eq!(config.colors.light.background, "#fafafa");
-        assert_eq!(config.colors.light.text, "#222222");
-        // Light defaults preserved for unset fields
-        assert_eq!(config.colors.light.text_muted, "#666666");
-        assert_eq!(config.colors.light.border, "#e0e0e0");
-        assert_eq!(config.colors.light.link, "#333333");
-        assert_eq!(config.colors.light.link_hover, "#000000");
-        // Dark entirely untouched
-        assert_eq!(config.colors.dark.background, "#000000");
-        assert_eq!(config.colors.dark.text, "#fafafa");
-    }
-
-    #[test]
-    fn merge_partial_font_weight_only() {
-        let partial: PartialSiteConfig = toml::from_str(
-            r#"
-            [font]
-            weight = "300"
-        "#,
-        )
-        .unwrap();
-        let config = SiteConfig::default().merge(partial);
-
-        assert_eq!(config.font.weight, "300");
-        assert_eq!(config.font.font, "Noto Sans");
-        assert_eq!(config.font.font_type, FontType::Sans);
-    }
-
-    #[test]
-    fn merge_multiple_sections_independently() {
-        let partial: PartialSiteConfig = toml::from_str(
-            r##"
-            [colors.dark]
-            background = "#1a1a1a"
-
-            [font]
-            font = "Lora"
-            font_type = "serif"
-        "##,
-        )
-        .unwrap();
-        let config = SiteConfig::default().merge(partial);
-
-        // Each section merged independently
-        assert_eq!(config.colors.dark.background, "#1a1a1a");
-        assert_eq!(config.colors.dark.text, "#fafafa");
-        assert_eq!(config.colors.light.background, "#ffffff");
-
-        assert_eq!(config.font.font, "Lora");
-        assert_eq!(config.font.font_type, FontType::Serif);
-        assert_eq!(config.font.weight, "600"); // preserved
-
-        // Sections not mentioned at all → full defaults
-        assert_eq!(config.images.quality, 90);
-        assert_eq!(config.thumbnails.aspect_ratio, [4, 5]);
-        assert_eq!(config.theme.mat_x.size, "3vw");
-    }
-
-    // =========================================================================
-    // Assets directory tests
-    // =========================================================================
-
-    #[test]
-    fn default_assets_dir() {
+    fn mat_x_to_css() {
         let config = SiteConfig::default();
-        assert_eq!(config.assets_dir, "assets");
+        assert_eq!(config.theme.mat_x.to_css(), "clamp(1rem, 3vw, 2.5rem)");
     }
 
     #[test]
-    fn parse_custom_assets_dir() {
-        let toml = r#"assets_dir = "site-assets""#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.assets_dir, "site-assets");
-    }
-
-    #[test]
-    fn merge_preserves_default_assets_dir() {
-        let partial: PartialSiteConfig = toml::from_str("[images]\nquality = 70\n").unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.assets_dir, "assets");
-    }
-
-    // =========================================================================
-    // Site description file tests
-    // =========================================================================
-
-    #[test]
-    fn default_site_description_file() {
+    fn generate_theme_css_includes_mat_variables() {
         let config = SiteConfig::default();
-        assert_eq!(config.site_description_file, "site");
+        let css = generate_theme_css(&config.theme);
+        assert!(css.contains("--mat-x: clamp(1rem, 3vw, 2.5rem)"));
+        assert!(css.contains("--mat-y: clamp(2rem, 6vw, 5rem)"));
+        assert!(css.contains("--thumbnail-gap: 0.2rem"));
+        assert!(css.contains("--grid-padding: 2rem"));
     }
 
-    #[test]
-    fn parse_custom_site_description_file() {
-        let toml = r#"site_description_file = "intro""#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.site_description_file, "intro");
-    }
-
-    #[test]
-    fn merge_preserves_default_site_description_file() {
-        let partial: PartialSiteConfig = toml::from_str("[images]\nquality = 70\n").unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.site_description_file, "site");
-    }
-
-    // =========================================================================
-    // Local font tests
-    // =========================================================================
+    // ----- font helpers -----
 
     #[test]
     fn default_font_is_google() {
-        let config = FontConfig::default();
-        assert!(!config.is_local());
-        assert!(config.stylesheet_url().is_some());
-        assert!(config.font_face_css().is_none());
+        let config = SiteConfig::default();
+        assert!(!config.font.is_local());
+        assert!(config.font.stylesheet_url().is_some());
+        assert!(config.font.font_face_css().is_none());
     }
 
     #[test]
     fn local_font_has_no_stylesheet_url() {
-        let config = FontConfig {
-            source: Some("fonts/MyFont.woff2".to_string()),
-            ..FontConfig::default()
-        };
-        assert!(config.is_local());
-        assert!(config.stylesheet_url().is_none());
+        let mut config = SiteConfig::default();
+        config.font.source = Some("fonts/MyFont.woff2".to_string());
+        assert!(config.font.is_local());
+        assert!(config.font.stylesheet_url().is_none());
     }
 
     #[test]
     fn local_font_generates_font_face_css() {
-        let config = FontConfig {
-            font: "My Custom Font".to_string(),
-            weight: "400".to_string(),
-            font_type: FontType::Sans,
-            source: Some("fonts/MyFont.woff2".to_string()),
-        };
-        let css = config.font_face_css().unwrap();
+        let mut config = SiteConfig::default();
+        config.font.font = "My Custom Font".to_string();
+        config.font.weight = "400".to_string();
+        config.font.font_type = FontType::Sans;
+        config.font.source = Some("fonts/MyFont.woff2".to_string());
+        let css = config.font.font_face_css().unwrap();
         assert!(css.contains("@font-face"));
         assert!(css.contains(r#"font-family: "My Custom Font""#));
         assert!(css.contains(r#"url("/fonts/MyFont.woff2")"#));
@@ -1990,31 +1334,35 @@ quality = 200
 
     #[test]
     fn parse_font_with_source() {
-        let toml = r#"
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r#"
 [font]
 font = "My Font"
 weight = "400"
 source = "fonts/myfont.woff2"
-"#;
-        let partial: PartialSiteConfig = toml::from_str(toml).unwrap();
-        let config = SiteConfig::default().merge(partial);
+"#,
+        );
+        let config = load_config(tmp.path()).unwrap();
         assert_eq!(config.font.font, "My Font");
         assert_eq!(config.font.source.as_deref(), Some("fonts/myfont.woff2"));
         assert!(config.font.is_local());
     }
 
     #[test]
-    fn merge_font_source_preserves_other_fields() {
-        let partial: PartialSiteConfig = toml::from_str(
+    fn parse_font_source_preserves_other_fields() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
             r#"
 [font]
 source = "fonts/custom.woff2"
 "#,
-        )
-        .unwrap();
-        let config = SiteConfig::default().merge(partial);
-        assert_eq!(config.font.font, "Noto Sans"); // default preserved
-        assert_eq!(config.font.weight, "600"); // default preserved
+        );
+        let config = load_config(tmp.path()).unwrap();
+        assert_eq!(config.font.font, "Noto Sans");
+        assert_eq!(config.font.weight, "600");
         assert_eq!(config.font.source.as_deref(), Some("fonts/custom.woff2"));
     }
 
@@ -2029,13 +1377,12 @@ source = "fonts/custom.woff2"
 
     #[test]
     fn generate_font_css_includes_font_face_for_local() {
-        let font = FontConfig {
-            font: "Local Font".to_string(),
-            weight: "700".to_string(),
-            font_type: FontType::Serif,
-            source: Some("fonts/local.woff2".to_string()),
-        };
-        let css = generate_font_css(&font);
+        let mut config = SiteConfig::default();
+        config.font.font = "Local Font".to_string();
+        config.font.weight = "700".to_string();
+        config.font.font_type = FontType::Serif;
+        config.font.source = Some("fonts/local.woff2".to_string());
+        let css = generate_font_css(&config.font);
         assert!(css.contains("@font-face"));
         assert!(css.contains("--font-family:"));
         assert!(css.contains("--font-weight: 700"));
@@ -2043,9 +1390,25 @@ source = "fonts/custom.woff2"
 
     #[test]
     fn generate_font_css_no_font_face_for_google() {
-        let font = FontConfig::default();
-        let css = generate_font_css(&font);
+        let config = SiteConfig::default();
+        let css = generate_font_css(&config.font);
         assert!(!css.contains("@font-face"));
         assert!(css.contains("--font-family:"));
+    }
+
+    // ----- unknown key rejection -----
+
+    #[test]
+    fn unknown_key_rejected_via_load_config() {
+        let tmp = TempDir::new().unwrap();
+        write_config(
+            tmp.path(),
+            r#"
+[images]
+qualty = 90
+"#,
+        );
+        let result = load_config(tmp.path());
+        assert!(result.is_err());
     }
 }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -331,11 +331,86 @@ pub struct CheckPayload<'a> {
     pub counts: Counts,
 }
 
-// ----- gen-config -----
+// ----- config -----
 
+/// JSON envelope for any `simple-gal config <action>` invocation.
+///
+/// Mirrors clapfig's [`ConfigResult`][clapfig::ConfigResult] but flattens
+/// each variant into a tagged `action` so consumers can branch on a single
+/// field without parsing free-form text.
 #[derive(Debug, Serialize)]
-pub struct GenConfigPayload {
-    pub toml: String,
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ConfigOpPayload {
+    /// `config gen` (printed to stdout).
+    Gen { toml: String },
+    /// `config gen --output PATH` (written to a file).
+    GenWritten { path: PathBuf },
+    /// `config schema` (printed to stdout).
+    Schema { schema: serde_json::Value },
+    /// `config schema --output PATH` (written to a file).
+    SchemaWritten { path: PathBuf },
+    /// `config get KEY`.
+    Get {
+        key: String,
+        value: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        doc: Vec<String>,
+    },
+    /// `config set KEY VALUE`.
+    Set { key: String, value: String },
+    /// `config unset KEY`.
+    Unset { key: String },
+    /// `config` / `config list` — flat key/value listing.
+    List { entries: Vec<ConfigListEntry> },
+}
+
+/// One row of a `config list` listing.
+#[derive(Debug, Serialize)]
+pub struct ConfigListEntry {
+    pub key: String,
+    pub value: String,
+}
+
+impl ConfigOpPayload {
+    /// Convert clapfig's `ConfigResult` into the wire envelope.
+    ///
+    /// For `Schema`, the JSON string clapfig produced is re-parsed into a
+    /// `serde_json::Value` so the schema lands as structured JSON inside
+    /// the envelope (rather than as a string-of-JSON that consumers would
+    /// have to double-parse).
+    pub fn from_result(result: &clapfig::ConfigResult) -> Self {
+        use clapfig::ConfigResult as R;
+        match result {
+            R::Template(t) => ConfigOpPayload::Gen { toml: t.clone() },
+            R::TemplateWritten { path } => ConfigOpPayload::GenWritten { path: path.clone() },
+            R::Schema(s) => ConfigOpPayload::Schema {
+                // Schema strings are produced by serde_json::to_string_pretty
+                // upstream, so re-parsing is infallible in practice.
+                schema: serde_json::from_str(s)
+                    .unwrap_or_else(|_| serde_json::Value::String(s.clone())),
+            },
+            R::SchemaWritten { path } => ConfigOpPayload::SchemaWritten { path: path.clone() },
+            R::KeyValue { key, value, doc } => ConfigOpPayload::Get {
+                key: key.clone(),
+                value: value.clone(),
+                doc: doc.clone(),
+            },
+            R::ValueSet { key, value } => ConfigOpPayload::Set {
+                key: key.clone(),
+                value: value.clone(),
+            },
+            R::ValueUnset { key } => ConfigOpPayload::Unset { key: key.clone() },
+            R::Listing { entries } => ConfigOpPayload::List {
+                entries: entries
+                    .iter()
+                    .map(|(k, v)| ConfigListEntry {
+                        key: k.clone(),
+                        value: v.clone(),
+                    })
+                    .collect(),
+            },
+        }
+    }
 }
 
 // ============================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use clapfig::{Clapfig, ConfigAction, ConfigArgs, ConfigSubcommand, SearchPath};
+use simple_gal::config::SiteConfig;
 use simple_gal::json_output::{
-    self, BuildPayload, CacheStatsPayload, CheckPayload, Counts, ErrorEnvelope, ErrorKind,
-    GenConfigPayload, GeneratePayload, OkEnvelope, ProcessPayload, ScanPayload,
+    self, BuildPayload, CacheStatsPayload, CheckPayload, ConfigOpPayload, Counts, ErrorEnvelope,
+    ErrorKind, GeneratePayload, OkEnvelope, ProcessPayload, ScanPayload,
 };
 use simple_gal::{config, generate, output, process, scan};
 use std::io::IsTerminal;
@@ -86,15 +88,21 @@ Metadata resolution (first available wins):
   Description: sidecar .txt → IPTC caption
   Gallery:     directory name; description from description.md or .txt
 
-Run 'simple-gal gen-config' to generate a documented config.toml.")]
+Run 'simple-gal config gen' to generate a documented config.toml,
+or 'simple-gal config schema' to emit a JSON Schema for tooling.")]
 #[command(version = version_string())]
 struct Cli {
     /// Content directory
     #[arg(long, default_value = "content", global = true)]
     source: PathBuf,
 
-    /// Output directory
-    #[arg(long, default_value = "dist", global = true)]
+    /// Output directory.
+    ///
+    /// Not marked `global = true` because the `config gen` and `config
+    /// schema` subcommands have their own `--output` flag (the file to
+    /// write the template / schema to), and clap's global-flag inheritance
+    /// would otherwise collide the two.
+    #[arg(long, default_value = "dist")]
     output: PathBuf,
 
     /// Directory for intermediate files (manifest, processed images)
@@ -127,8 +135,8 @@ enum Command {
     Build(CacheArgs),
     /// Validate content directory without building
     Check,
-    /// Print a stock config.toml with all options documented
-    GenConfig,
+    /// Manage site configuration: gen, schema, list, get, set, unset
+    Config(ConfigArgs),
 }
 
 /// Wrapper around any command error tagged with an [`ErrorKind`] so the
@@ -279,7 +287,7 @@ fn run(cli: &Cli, format: OutputFormat) -> Result<(), CliError> {
         Command::Generate => run_generate(cli, json_mode, quiet),
         Command::Build(cache_args) => run_build(cli, cache_args, json_mode, quiet),
         Command::Check => run_check(cli, json_mode, quiet),
-        Command::GenConfig => run_gen_config(json_mode),
+        Command::Config(args) => run_config(cli, args, json_mode),
     }
 }
 
@@ -508,18 +516,64 @@ fn run_check(cli: &Cli, json_mode: bool, quiet: bool) -> Result<(), CliError> {
     Ok(())
 }
 
-fn run_gen_config(json_mode: bool) -> Result<(), CliError> {
-    let toml = config::stock_config_toml();
+/// Dispatch the `simple-gal config <action>` subcommand group through
+/// clapfig. clapfig owns gen / schema / list / get / set / unset; we wrap
+/// the typed `ConfigResult` it returns in our JSON envelope when
+/// `--format json` is in effect, otherwise print it via `Display`.
+fn run_config(cli: &Cli, args: &ConfigArgs, json_mode: bool) -> Result<(), CliError> {
+    // ConfigArgs::into_action takes self, but we only have a &ConfigArgs
+    // (we never own the Cli value). Mirror its dispatch by hand so we can
+    // build a fresh ConfigAction without consuming the args.
+    let action = config_action_from_args(args);
+
+    let builder = Clapfig::builder::<SiteConfig>()
+        .app_name("simple-gal")
+        .file_name("config.toml")
+        .search_paths(vec![SearchPath::Path(cli.source.clone())])
+        .no_env()
+        .post_validate(|c: &SiteConfig| c.validate().map_err(|e| e.to_string()));
+
+    let result = builder.handle(&action).tag(ErrorKind::Config)?;
+
     if json_mode {
-        let payload = GenConfigPayload {
-            toml: toml.to_string(),
-        };
-        json_output::emit_stdout(&OkEnvelope::new("gen-config", payload))
-            .tag(ErrorKind::Internal)?;
+        let payload = ConfigOpPayload::from_result(&result);
+        json_output::emit_stdout(&OkEnvelope::new("config", payload)).tag(ErrorKind::Internal)?;
     } else {
-        print!("{toml}");
+        println!("{result}");
     }
     Ok(())
+}
+
+/// Borrow-friendly mirror of [`ConfigArgs::into_action`].
+///
+/// `ConfigArgs` doesn't implement `Clone`, so we can't use the upstream
+/// helper from a `&ConfigArgs`. Re-implementing the match by hand is
+/// trivial and lets the rest of `run` keep its `&Cli` shape.
+fn config_action_from_args(args: &ConfigArgs) -> ConfigAction {
+    match args.action.as_ref() {
+        None | Some(ConfigSubcommand::List) => ConfigAction::List {
+            scope: args.scope.clone(),
+        },
+        Some(ConfigSubcommand::Gen { output }) => ConfigAction::Gen {
+            output: output.clone(),
+        },
+        Some(ConfigSubcommand::Schema { output }) => ConfigAction::Schema {
+            output: output.clone(),
+        },
+        Some(ConfigSubcommand::Get { key }) => ConfigAction::Get {
+            key: key.clone(),
+            scope: args.scope.clone(),
+        },
+        Some(ConfigSubcommand::Set { key, value }) => ConfigAction::Set {
+            key: key.clone(),
+            value: value.clone(),
+            scope: args.scope.clone(),
+        },
+        Some(ConfigSubcommand::Unset { key }) => ConfigAction::Unset {
+            key: key.clone(),
+            scope: args.scope.clone(),
+        },
+    }
 }
 
 /// Initialize the rayon thread pool based on processing config.

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -53,10 +53,11 @@
 //! - No duplicate image numbers within an album
 //! - Every album must have at least one image
 
-use crate::config::{self, SiteConfig};
+use crate::config::{self, SiteConfig, SiteConfigLayer};
 use crate::metadata;
 use crate::naming::parse_entry_name;
 use crate::types::{NavItem, Page};
+use confique::Layer;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
@@ -134,20 +135,18 @@ pub fn scan(root: &Path) -> Result<Manifest, ScanError> {
     let mut albums = Vec::new();
     let mut nav_items = Vec::new();
 
-    // Build the config chain: stock defaults → root config.toml
-    let base = SiteConfig::default();
-    let root_partial = config::load_partial_config(root)?;
-    let root_config = match root_partial {
-        Some(partial) => base.merge(partial),
-        None => base,
-    };
+    // Resolve the root config (used for assets_dir, site_description_file,
+    // and the manifest output) and capture the root layer to seed the
+    // per-directory cascade.
+    let root_layer = config::load_layer(root)?.unwrap_or_else(SiteConfigLayer::empty);
+    let root_config = config::finalize_layer(root_layer.clone())?;
 
     scan_directory(
         root,
         root,
         &mut albums,
         &mut nav_items,
-        &root_config,
+        &root_layer,
         &root_config.assets_dir,
     )?;
 
@@ -273,7 +272,7 @@ fn scan_directory(
     root: &Path,
     albums: &mut Vec<Album>,
     nav_items: &mut Vec<NavItem>,
-    inherited_config: &SiteConfig,
+    inherited_layer: &SiteConfigLayer,
     assets_dir: &str,
 ) -> Result<(), ScanError> {
     let entries = collect_entries(path, if path == root { Some(assets_dir) } else { None })?;
@@ -287,19 +286,20 @@ fn scan_directory(
         return Err(ScanError::MixedContent(path.to_path_buf()));
     }
 
-    // Merge any local config.toml onto the inherited config (skip root — already handled)
-    let effective_config = if path != root {
-        match config::load_partial_config(path)? {
-            Some(partial) => inherited_config.clone().merge(partial),
-            None => inherited_config.clone(),
+    // Layer any local config.toml onto the inherited layer (skip root — its
+    // file was already folded into `inherited_layer` by `scan`).
+    let effective_layer = if path != root {
+        match config::load_layer(path)? {
+            Some(local) => local.with_fallback(inherited_layer.clone()),
+            None => inherited_layer.clone(),
         }
     } else {
-        inherited_config.clone()
+        inherited_layer.clone()
     };
 
     if !images.is_empty() {
-        // This is an album
-        effective_config.validate()?;
+        // This is an album — resolve and validate the cascade leaf.
+        let effective_config = config::finalize_layer(effective_layer)?;
         let album = build_album(path, root, &images, effective_config)?;
         let in_nav = album.in_nav;
         let title = album.title.clone();
@@ -335,7 +335,7 @@ fn scan_directory(
                 root,
                 albums,
                 &mut child_nav,
-                &effective_config,
+                &effective_layer,
                 assets_dir,
             )?;
         }

--- a/tests/cli_json.rs
+++ b/tests/cli_json.rs
@@ -48,16 +48,48 @@ fn check_json_envelope() {
 }
 
 #[test]
-fn gen_config_json_envelope() {
+fn config_gen_json_envelope() {
     let output = simple_gal()
-        .args(["--format", "json", "gen-config"])
+        .args(["--format", "json", "config", "gen"])
         .output()
         .expect("run simple-gal");
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "exit={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
     let v = parse_json(&output.stdout);
-    assert_eq!(v["command"], "gen-config");
+    assert_eq!(v["command"], "config");
+    assert_eq!(v["data"]["action"], "gen");
     let toml = v["data"]["toml"].as_str().unwrap();
     assert!(toml.contains("site_title"));
+}
+
+#[test]
+fn config_schema_json_envelope() {
+    let output = simple_gal()
+        .args(["--format", "json", "config", "schema"])
+        .output()
+        .expect("run simple-gal");
+    assert!(
+        output.status.success(),
+        "exit={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = parse_json(&output.stdout);
+    assert_eq!(v["command"], "config");
+    assert_eq!(v["data"]["action"], "schema");
+    let schema = &v["data"]["schema"];
+    assert_eq!(
+        schema["$schema"], "https://json-schema.org/draft/2020-12/schema",
+        "schema should declare draft 2020-12 dialect"
+    );
+    assert_eq!(schema["type"], "object");
+    // The top-level SiteConfig must be present in the schema's properties.
+    assert!(schema["properties"]["site_title"].is_object());
+    assert!(schema["properties"]["colors"]["properties"]["light"].is_object());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Migrate `SiteConfig` to `#[derive(confique::Config)]` and adopt clapfig 0.15's `ConfigArgs` for the full `simple-gal config gen|schema|list|get|set|unset` command surface — schema generation (Draft 2020-12, intended for GUI form generators) is the headline.
- Net delete: ~430 lines of `PartialSiteConfig` types, hand-written `merge()` methods, and the hand-rolled `stock_config_toml()` template string. Defaults now live as `#[config(default = ...)]` annotations on the struct fields and the template is auto-generated from doc comments, so the two can no longer drift.
- Per-directory cascade in `scan.rs` now threads `SiteConfigLayer` (the confique-generated sparse type) instead of resolved `SiteConfig`s, folding layers via `Layer::with_fallback` and finalizing only at album leaves. Cascade semantics are unchanged.

## What's new for users

```bash
# Auto-generated commented TOML template (replaces gen-config)
simple-gal config gen
simple-gal config gen -o config.toml

# JSON Schema for GUI form generators / IDE integrations
simple-gal config schema
simple-gal config schema -o site.schema.json

# Inspect the resolved config
simple-gal config            # bare = list
simple-gal config list
simple-gal config get site_title

# Persistence placeholders (error with NoPersistPath until a scope is wired)
simple-gal config set thumbnails.size 500
simple-gal config unset images.quality
```

All variants honor `--format json` via the new `ConfigOpPayload` envelope (`{ok, command: "config", data: {action, ...}}`), so automation can branch on `data.action` without scraping text.

## Architectural notes

- **Custom `Deserialize` on `SiteConfig`** routes any direct deserialize (manifest reads in `process.rs`, JSON test fixtures, anything calling `serde_json::from_str::<SiteConfig>`) through the same layer + defaults pipeline. A sparse `"config": {}` in a manifest still produces a fully populated config — no fixtures needed updating.
- **`ColorScheme` split into `LightColors`/`DarkColors`, `ClampSize` split into `MatX`/`MatY`.** confique nested defaults come from the inner type, so two instances of one type can't have different defaults; splitting is the only way to keep accurate per-side defaults visible in both the schema and the generated template.
- **Semantic validation** (quality range, non-zero ratios, non-empty `images.sizes`) wired through clapfig's `.post_validate()` hook on every `simple-gal config` invocation. `SiteConfig::validate()` stays for the per-directory cascade in `scan.rs`.
- **`--output` is no longer a global flag** — it collided with clapfig's `config gen --output` / `config schema --output`. Only `build` and `generate` use it, so it now lives on those subcommands directly. `--source` and `--temp-dir` are still global.
- **`gen-config` removed** in favor of `simple-gal config gen`. Existing scripts will need updating.

## Dependencies

- `clapfig` bumped from `0.13` → `0.15` (adds `Resolver`, `post_validate`, schema generation, `ConfigArgs::Schema` variant)
- New direct dep: `confique = "0.4"` with `toml` feature (used for the `Config` derive macro and `Layer` trait)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 399/399 passing (379 lib + 9 cli_json + 8 cli_scan + 2 cli_config_errors + 1 doctest)
- [x] `simple-gal config gen` smoke test — full template renders
- [x] `simple-gal config schema` smoke test — valid Draft 2020-12 schema with defaults / descriptions / required arrays
- [x] `simple-gal config get site_title` — reads from default config
- [x] End-to-end `simple-gal --source fixtures/content build` — full pipeline still works (cascade, validation, generate stage)
- [ ] Manual review: scan a real content tree with nested per-album `config.toml` overrides to confirm cascade semantics

## Follow-up (not in this PR)

- Swap the hand-rolled cascade in `scan.rs` for `clapfig::Resolver::resolve_at` so the per-directory walk goes through clapfig's reusable resolver (with file caching). The type is now confique-shaped, so this is the next clean reduction.
- Wire `.persist_scope()` so `simple-gal config set` / `unset` actually write to a file instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)