### PR TITLE
feat: build-pipeline hook for [auto_indexing].auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `[auto_indexing].auto` now does something: `build` consults it and runs the reindex walker over the source tree before scan when it is set to `source_only` or `both`. After any on-disk rename, the processing cache at `<temp-dir>/processed/` is wiped so the process stage rebuilds from scratch — a deliberately coarse invalidation for the first cut; per-file content-addressed reuse across renames is a later optimization. `off` stays the default and leaves the source untouched. `export_only` (source-untouched manifest rewrite) still errors with a clear "not yet supported" message; it lands in a follow-up.
+
 ## [0.18.0] - 2026-04-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ A minimal static site generator for fine art photography portfolios.
 
 Three-stage pipeline: **scan** (filesystem → manifest) → **process** (responsive images + thumbnails) → **generate** (HTML site with inline CSS).
 
+When `[auto_indexing].auto` is set to `source_only` or `both` in the config, an optional **stage 0** runs `reindex` over the source tree before scan, normalizing `NNN-` prefixes (and wiping the processing cache if anything moved). `off` (default) skips the hook entirely.
+
 ```bash
 cargo run -- build --source content --output dist
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,6 +473,9 @@ fn run_build(cli: &Cli, cache_args: &CacheArgs, format: OutputFormat) -> Result<
 
     std::fs::create_dir_all(&cli.temp_dir).tag(ErrorKind::Io)?;
 
+    // === Stage 0: Auto-reindex (opt-in via [auto_indexing].auto) ===
+    maybe_auto_reindex(cli, &source, stage_text)?;
+
     // === Stage 1: Scan ===
     if stage_text {
         println!("==> Stage 1: Scanning {}", source.display());
@@ -701,6 +704,88 @@ fn init_thread_pool(processing: &config::ProcessingConfig) {
 /// Resolve the content source directory for the build command.
 fn resolve_build_source(cli_source: &Path) -> PathBuf {
     cli_source.to_path_buf()
+}
+
+/// Pre-scan hook: consult `[auto_indexing].auto` and reindex the source
+/// tree if the user has opted in.
+///
+/// Behavior per mode:
+///
+/// - `off` (default): no-op.
+/// - `source_only` / `both`: walk the source tree through `reindex::reindex_tree`
+///   with the configured `spacing`/`padding`. Any on-disk rename invalidates
+///   the processing cache (by removing `<temp-dir>/processed/`); the
+///   subsequent process stage rebuilds from scratch. Cache invalidation
+///   here is deliberately coarse — per-file content-addressed caching could
+///   preserve more state across renames, but that's a follow-up optimization.
+/// - `export_only`: not yet implemented. Returns an error telling the user
+///   to use the manual `simple-gal reindex` command or switch modes; the
+///   source-untouched manifest-rewrite path lands in a later release.
+fn maybe_auto_reindex(cli: &Cli, source: &Path, text_mode: bool) -> Result<(), CliError> {
+    let site_config = config::load_config(&cli.source).tag(ErrorKind::Config)?;
+    let auto = site_config.auto_indexing.auto.clone();
+    let spacing = site_config.auto_indexing.spacing;
+    let padding = site_config.auto_indexing.padding;
+
+    use config::AutoIndexingMode;
+    match auto {
+        AutoIndexingMode::Off => Ok(()),
+        AutoIndexingMode::SourceOnly | AutoIndexingMode::Both => {
+            if text_mode {
+                println!(
+                    "==> Stage 0: Auto-reindex (mode=source_only, spacing={spacing}, padding={padding})"
+                );
+            }
+            let opts = reindex::WalkOptions {
+                is_root: true,
+                assets_dir: Some(site_config.assets_dir.as_str()),
+                site_description_file: site_config.site_description_file.as_str(),
+            };
+            let reports = reindex::reindex_tree(source, spacing, padding, false, false, &opts)
+                .tag(ErrorKind::Reindex)?;
+            let total_renames: usize = reports.iter().map(|r| r.plan.len()).sum();
+            if text_mode {
+                if total_renames == 0 {
+                    println!("  (already normalized)");
+                } else {
+                    println!(
+                        "  {total_renames} rename(s) across {} director{}.",
+                        reports.iter().filter(|r| !r.plan.is_empty()).count(),
+                        if reports.iter().filter(|r| !r.plan.is_empty()).count() == 1 {
+                            "y"
+                        } else {
+                            "ies"
+                        }
+                    );
+                }
+            }
+            // Coarse cache invalidation: if anything on disk moved, throw
+            // away the processed dir so the process stage can't hand back
+            // stale variants keyed by old paths. See doc-comment above.
+            if total_renames > 0 {
+                let processed_dir = cli.temp_dir.join("processed");
+                if processed_dir.exists() {
+                    if text_mode {
+                        println!(
+                            "  Invalidating processing cache ({})",
+                            processed_dir.display()
+                        );
+                    }
+                    std::fs::remove_dir_all(&processed_dir).tag(ErrorKind::Io)?;
+                }
+            }
+            Ok(())
+        }
+        AutoIndexingMode::ExportOnly => {
+            let msg: Box<dyn std::error::Error + 'static> =
+                "auto_indexing.auto = \"export_only\" is not yet supported. \
+                 Use \"source_only\" (renames source files in place) or run \
+                 `simple-gal reindex` manually; export-only manifest rewrite \
+                 lands in a follow-up release."
+                    .into();
+            Err(CliError::new(ErrorKind::Config, msg))
+        }
+    }
 }
 
 /// Run `simple-gal reindex`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -722,7 +722,10 @@ fn resolve_build_source(cli_source: &Path) -> PathBuf {
 ///   to use the manual `simple-gal reindex` command or switch modes; the
 ///   source-untouched manifest-rewrite path lands in a later release.
 fn maybe_auto_reindex(cli: &Cli, source: &Path, text_mode: bool) -> Result<(), CliError> {
-    let site_config = config::load_config(&cli.source).tag(ErrorKind::Config)?;
+    // Load from the resolved `source`, not `&cli.source` — `resolve_build_source`
+    // is a passthrough today but could normalize/canonicalize in the future,
+    // and a stale reference here would silently diverge.
+    let site_config = config::load_config(source).tag(ErrorKind::Config)?;
     let auto = site_config.auto_indexing.auto.clone();
     let spacing = site_config.auto_indexing.spacing;
     let padding = site_config.auto_indexing.padding;
@@ -730,10 +733,15 @@ fn maybe_auto_reindex(cli: &Cli, source: &Path, text_mode: bool) -> Result<(), C
     use config::AutoIndexingMode;
     match auto {
         AutoIndexingMode::Off => Ok(()),
-        AutoIndexingMode::SourceOnly | AutoIndexingMode::Both => {
+        mode @ (AutoIndexingMode::SourceOnly | AutoIndexingMode::Both) => {
             if text_mode {
+                let mode_name = match mode {
+                    AutoIndexingMode::SourceOnly => "source_only",
+                    AutoIndexingMode::Both => "both",
+                    _ => unreachable!(),
+                };
                 println!(
-                    "==> Stage 0: Auto-reindex (mode=source_only, spacing={spacing}, padding={padding})"
+                    "==> Stage 0: Auto-reindex (mode={mode_name}, spacing={spacing}, padding={padding})"
                 );
             }
             let opts = reindex::WalkOptions {

--- a/tests/cli_build_reindex.rs
+++ b/tests/cli_build_reindex.rs
@@ -1,0 +1,229 @@
+//! End-to-end tests for the `[auto_indexing].auto` build hook.
+//!
+//! Each test builds a tiny self-contained content tree in a TempDir, runs
+//! `simple-gal build` against it, and asserts on the final state of both
+//! the source tree (`source_only` and `both` rename in place; `off` does
+//! not) and the generated output.
+//!
+//! We intentionally don't exercise the full image-processing pipeline with
+//! real JPEGs here — the hook runs *before* scan, so placeholder images are
+//! enough to reach the rename step. The process stage will fail to decode
+//! them, but we capture output before that point where needed.
+//!
+//! The one mode not covered by these tests is `export_only`, which simply
+//! errors with a clear "not yet supported" message in the current release.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn simple_gal() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_simple-gal"))
+}
+
+/// Minimal real AVIF byte — the tiniest valid file the decoder will accept
+/// so the build can reach the generate stage without panicking on image
+/// decode. Taken from the existing fixture used by other CLI tests.
+fn sample_image_bytes() -> Vec<u8> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/content/010-Landscapes/001-dawn.jpg");
+    fs::read(path).expect("fixture image missing")
+}
+
+/// Build a content tree at `root` with two images numbered at arbitrary
+/// sparse positions, a `config.toml` enabling the given auto mode, and a
+/// minimal site description.
+fn seed_content(root: &Path, auto_mode: &str) {
+    fs::create_dir_all(root).unwrap();
+    fs::write(
+        root.join("config.toml"),
+        format!(
+            r#"
+site_title = "Test"
+
+[auto_indexing]
+auto = "{auto_mode}"
+spacing = 1
+padding = 3
+
+[images]
+sizes = [400]
+quality = 70
+"#
+        ),
+    )
+    .unwrap();
+    let album = root.join("5-Album");
+    fs::create_dir_all(&album).unwrap();
+    let bytes = sample_image_bytes();
+    fs::write(album.join("1-first.jpg"), &bytes).unwrap();
+    fs::write(album.join("10-second.jpg"), &bytes).unwrap();
+}
+
+fn run_build(source: &Path, temp: &Path, output: &Path) -> std::process::Output {
+    simple_gal()
+        .args([
+            "--source",
+            source.to_str().unwrap(),
+            "--temp-dir",
+            temp.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--quiet",
+            "build",
+        ])
+        .output()
+        .expect("build command failed to spawn")
+}
+
+// ----------------------------------------------------------------------------
+// off (default behavior)
+// ----------------------------------------------------------------------------
+
+#[test]
+fn auto_off_leaves_source_alone() {
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "off");
+
+    let _ = run_build(&source, &temp, &output);
+
+    // Source filenames unchanged.
+    assert!(source.join("5-Album/1-first.jpg").exists());
+    assert!(source.join("5-Album/10-second.jpg").exists());
+    assert!(!source.join("010-Album").exists());
+}
+
+// ----------------------------------------------------------------------------
+// source_only
+// ----------------------------------------------------------------------------
+
+#[test]
+fn auto_source_only_renames_source_in_place() {
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "source_only");
+
+    let _ = run_build(&source, &temp, &output);
+
+    // Album dir renumbered at root (position 1 → 010).
+    assert!(source.join("010-Album").exists());
+    assert!(!source.join("5-Album").exists());
+    // Images inside renumbered (positions 1, 2 → 010, 020).
+    assert!(source.join("010-Album/010-first.jpg").exists());
+    assert!(source.join("010-Album/020-second.jpg").exists());
+    assert!(!source.join("010-Album/1-first.jpg").exists());
+}
+
+// ----------------------------------------------------------------------------
+// both (same on-disk effect as source_only)
+// ----------------------------------------------------------------------------
+
+#[test]
+fn auto_both_renames_source_like_source_only() {
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "both");
+
+    let _ = run_build(&source, &temp, &output);
+
+    assert!(source.join("010-Album/010-first.jpg").exists());
+    assert!(source.join("010-Album/020-second.jpg").exists());
+}
+
+// ----------------------------------------------------------------------------
+// export_only (explicit not-yet-supported error)
+// ----------------------------------------------------------------------------
+
+#[test]
+fn auto_export_only_errors_clearly() {
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "export_only");
+
+    let result = run_build(&source, &temp, &output);
+    assert!(!result.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("export_only") && stderr.contains("not yet supported"),
+        "stderr did not mention export_only unsupported: {stderr}"
+    );
+    // Source untouched.
+    assert!(source.join("5-Album/1-first.jpg").exists());
+}
+
+// ----------------------------------------------------------------------------
+// Cache invalidation
+// ----------------------------------------------------------------------------
+
+#[test]
+fn source_only_invalidates_processed_dir_on_rename() {
+    // Seed a stale `processed/` directory that would otherwise be reused,
+    // confirm the hook wipes it when it actually renames something.
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "source_only");
+
+    let processed = temp.join("processed");
+    fs::create_dir_all(&processed).unwrap();
+    let stale_marker = processed.join("stale-marker.txt");
+    fs::write(&stale_marker, "from a previous build").unwrap();
+
+    let _ = run_build(&source, &temp, &output);
+
+    // The stale marker should be gone because the hook wiped the cache.
+    assert!(
+        !stale_marker.exists(),
+        "expected processed/ to have been wiped after rename"
+    );
+}
+
+#[test]
+fn source_only_preserves_processed_dir_when_no_renames_needed() {
+    // If the source is already normalized, the hook shouldn't touch the
+    // cache directory.
+    let workspace = TempDir::new().unwrap();
+    let source = workspace.path().join("content");
+    let temp = workspace.path().join("temp");
+    let output = workspace.path().join("dist");
+    seed_content(&source, "source_only");
+
+    // First build: renames happen, cache gets populated.
+    let _ = run_build(&source, &temp, &output);
+
+    // Plant a marker in the freshly-built processed/ directory.
+    let processed = temp.join("processed");
+    if !processed.exists() {
+        // If the process stage failed (placeholder images), skip this
+        // assertion — the cache-preservation path still exercises here.
+        fs::create_dir_all(&processed).unwrap();
+    }
+    let marker = processed.join("second-build-marker.txt");
+    fs::write(&marker, "should survive").unwrap();
+
+    // Second build on already-normalized tree: no renames, no wipe.
+    let _ = run_build(&source, &temp, &output);
+
+    assert!(
+        marker.exists(),
+        "expected cache marker to survive a no-op auto-reindex"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Helper: PathBuf import check (silence unused warning if CI enables strict)
+// ----------------------------------------------------------------------------
+
+#[allow(dead_code)]
+fn _pathbuf_use(_: PathBuf) {}

--- a/tests/cli_build_reindex.rs
+++ b/tests/cli_build_reindex.rs
@@ -5,16 +5,16 @@
 //! the source tree (`source_only` and `both` rename in place; `off` does
 //! not) and the generated output.
 //!
-//! We intentionally don't exercise the full image-processing pipeline with
-//! real JPEGs here — the hook runs *before* scan, so placeholder images are
-//! enough to reach the rename step. The process stage will fail to decode
-//! them, but we capture output before that point where needed.
+//! Focus is on the hook's on-disk effects before scan; the process stage
+//! may fail on the minimal reused fixture image but the rename work we
+//! assert on has already happened by then.
 //!
-//! The one mode not covered by these tests is `export_only`, which simply
-//! errors with a clear "not yet supported" message in the current release.
+//! `export_only` is covered only for its current unsupported behavior —
+//! we verify it errors with a clear "not yet supported" message rather
+//! than exercising a successful rename/build path.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -22,9 +22,10 @@ fn simple_gal() -> Command {
     Command::new(env!("CARGO_BIN_EXE_simple-gal"))
 }
 
-/// Minimal real AVIF byte — the tiniest valid file the decoder will accept
-/// so the build can reach the generate stage without panicking on image
-/// decode. Taken from the existing fixture used by other CLI tests.
+/// Reuse a real JPEG fixture from `fixtures/content/` so the decoder
+/// doesn't panic when the build reaches the process stage. The tests
+/// only care about the pre-scan rename step; this just needs to be a
+/// valid image the pipeline can open.
 fn sample_image_bytes() -> Vec<u8> {
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/content/010-Landscapes/001-dawn.jpg");
@@ -77,6 +78,21 @@ fn run_build(source: &Path, temp: &Path, output: &Path) -> std::process::Output 
         .expect("build command failed to spawn")
 }
 
+/// `run_build` wrapper that asserts the build command succeeded. The
+/// minimal placeholder image used here is a real JPEG, so the pipeline
+/// goes end-to-end. Using this on passing-path tests prevents a silent
+/// `process` / `generate` failure from faking a green test via surviving
+/// filesystem state.
+fn run_build_ok(source: &Path, temp: &Path, output: &Path) {
+    let result = run_build(source, temp, output);
+    assert!(
+        result.status.success(),
+        "build failed unexpectedly.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
 // ----------------------------------------------------------------------------
 // off (default behavior)
 // ----------------------------------------------------------------------------
@@ -89,7 +105,7 @@ fn auto_off_leaves_source_alone() {
     let output = workspace.path().join("dist");
     seed_content(&source, "off");
 
-    let _ = run_build(&source, &temp, &output);
+    run_build_ok(&source, &temp, &output);
 
     // Source filenames unchanged.
     assert!(source.join("5-Album/1-first.jpg").exists());
@@ -109,7 +125,7 @@ fn auto_source_only_renames_source_in_place() {
     let output = workspace.path().join("dist");
     seed_content(&source, "source_only");
 
-    let _ = run_build(&source, &temp, &output);
+    run_build_ok(&source, &temp, &output);
 
     // Album dir renumbered at root (position 1 → 010).
     assert!(source.join("010-Album").exists());
@@ -132,7 +148,7 @@ fn auto_both_renames_source_like_source_only() {
     let output = workspace.path().join("dist");
     seed_content(&source, "both");
 
-    let _ = run_build(&source, &temp, &output);
+    run_build_ok(&source, &temp, &output);
 
     assert!(source.join("010-Album/010-first.jpg").exists());
     assert!(source.join("010-Album/020-second.jpg").exists());
@@ -180,7 +196,7 @@ fn source_only_invalidates_processed_dir_on_rename() {
     let stale_marker = processed.join("stale-marker.txt");
     fs::write(&stale_marker, "from a previous build").unwrap();
 
-    let _ = run_build(&source, &temp, &output);
+    run_build_ok(&source, &temp, &output);
 
     // The stale marker should be gone because the hook wiped the cache.
     assert!(
@@ -199,31 +215,24 @@ fn source_only_preserves_processed_dir_when_no_renames_needed() {
     let output = workspace.path().join("dist");
     seed_content(&source, "source_only");
 
-    // First build: renames happen, cache gets populated.
-    let _ = run_build(&source, &temp, &output);
+    // First build: renames happen, cache gets populated by process stage.
+    run_build_ok(&source, &temp, &output);
 
-    // Plant a marker in the freshly-built processed/ directory.
+    // Plant a marker in the freshly-built processed/ dir.
     let processed = temp.join("processed");
-    if !processed.exists() {
-        // If the process stage failed (placeholder images), skip this
-        // assertion — the cache-preservation path still exercises here.
-        fs::create_dir_all(&processed).unwrap();
-    }
+    assert!(
+        processed.exists(),
+        "expected process stage to create {}",
+        processed.display()
+    );
     let marker = processed.join("second-build-marker.txt");
     fs::write(&marker, "should survive").unwrap();
 
     // Second build on already-normalized tree: no renames, no wipe.
-    let _ = run_build(&source, &temp, &output);
+    run_build_ok(&source, &temp, &output);
 
     assert!(
         marker.exists(),
         "expected cache marker to survive a no-op auto-reindex"
     );
 }
-
-// ----------------------------------------------------------------------------
-// Helper: PathBuf import check (silence unused warning if CI enables strict)
-// ----------------------------------------------------------------------------
-
-#[allow(dead_code)]
-fn _pathbuf_use(_: PathBuf) {}


### PR DESCRIPTION
## Summary

Closes the last open piece of the auto-reindex feature (task #6 from the original spec). `simple-gal build` now consults `[auto_indexing].auto` before scanning:

| Mode          | Behavior                                                                                          |
| ------------- | ------------------------------------------------------------------------------------------------- |
| `off`         | Default. Hook does nothing.                                                                       |
| `source_only` | Walks the source via `reindex_tree`, renames in place, wipes `<temp-dir>/processed/` on changes.  |
| `both`        | Same on-disk effect as `source_only` (intent marker).                                             |
| `export_only` | Errors with a clear `ErrorKind::Config` message — manifest-rewrite implementation deferred.       |

Cache invalidation is intentionally coarse: any rename → wipe `processed/`. The cache is content-addressed (per v0.10.0) so a smarter implementation could preserve cached AVIFs across renames, but that's a later optimization. For the first cut, blow it away and let the process stage rebuild.

## Files

- `src/main.rs` — `maybe_auto_reindex` runs as "stage 0" before scan inside `run_build`.
- `tests/cli_build_reindex.rs` — 6 end-to-end tests exercising each mode + cache invalidation.
- `CHANGELOG.md` — `[Unreleased]` entry describing the new behavior.
- `CLAUDE.md` — one-line note about the optional stage 0.

## Deferred

- `export_only` mode: in-memory manifest rewrite that uses normalized prefixes for output paths/URLs while leaving source files alone. Returns a clear "not yet supported" error today.
- Cache reuse across renames (instead of full wipe).

## Test plan

- [x] `cargo test` — 462 lib + 6 new integration + others, all green.
- [x] `cargo fmt --check` clean.
- [x] Smoke: `auto = "source_only"` renames source files in place; `auto = "off"` leaves them alone; `auto = "export_only"` errors out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)