### PR TITLE
feat: data-model phase 1 — canonical_images flat view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Data-model refactor Phase 1: scan now emits a flat `Manifest.canonical_images` list of unique source images keyed by SHA-256 content hash, and every per-album `Image` carries a `canonical_id` pointing at its entry. Byte-identical images in two albums collapse to one canonical entry with both paths captured (first occurrence wins `source_path`; others land in `aliases`). No consumer behavior changes yet — process and generate still walk `Album.images` and ignore the flat view. This lands the new shape alongside the nested one so later phases can migrate consumers one by one. See `docs/dev/data-model-refactor.md` for the full plan.
+
 ## [0.19.0] - 2026-04-21
 
 ### Added

--- a/docs/dev/data-model-refactor.md
+++ b/docs/dev/data-model-refactor.md
@@ -180,52 +180,78 @@ cut once.
 Each phase is its own PR, each lands with a green suite, each is
 reviewable standalone. Targets `main`.
 
-### Phase 1 — Introduce the types, scan produces both shapes
+### Phase 1 — Introduce canonical image IDs, scan links both views *(landed)*
 
-- Add `ImageId`, flat `Manifest.images: Vec<Image>`, `ImageRef`
-  alongside the existing `Album.images: Vec<Image>`.
-- Scan populates both: nested vec (old) AND flat vec + refs (new).
-- No consumer changes yet. All existing tests still pass.
-- Unit tests: scan produces consistent views between the two shapes;
-  byte-identical images in two albums collapse to one `Image` in the
-  flat vec, two `ImageRef` in the albums.
-- Estimated: ~400-600 LOC, 2-3 days.
+- Add `ImageId`, `CanonicalImage { id, source_path, aliases }`,
+  `Manifest.canonical_images: Vec<CanonicalImage>`, and
+  `Image.canonical_id: Option<ImageId>` while keeping the existing
+  `Album.images: Vec<Image>` shape exactly as it was. No type renames
+  at this layer — consumer code still reads `album.images` and doesn't
+  see the new fields yet.
+- Scan populates both views in one pass: albums still contain their
+  per-album `Image` records, and a post-scan `build_canonical_index`
+  hashes each source file (SHA-256, reusing `cache::hash_file` so the
+  manifest and cache share the same digest format), dedupes by
+  `ImageId`, and stamps every ref's `canonical_id`.
+- No behavior change. All existing tests still pass.
+- Unit tests: byte-identical images in two albums collapse to one
+  canonical entry with both paths captured (first scan occurrence
+  wins `source_path`; others land in `aliases`); byte-different
+  images with the same filename get separate IDs; `aliases` stays
+  empty for singletons; every `Image.canonical_id` points at a real
+  canonical entry.
+- Landed: ~600 LOC, including the plan doc.
 
-### Phase 2 — Migrate process to the new shape
+### Phase 2 — Migrate process to consume canonical images
 
-- Process stage iterates `(ImageRef, album.resolved_config)` tuples.
-  For each ref it computes the params hash from the album's resolved
-  config and consults the cache; cache hits skip re-encoding, misses
-  encode once and insert. **One encode per unique
-  `(content_hash, params_hash)` across the whole site** — two albums
-  with the same config on a shared image = one encode; two albums
-  with different configs = two encodes. This is already the cache's
-  existing contract (`cache.rs:137`).
-- Output path construction walks refs per album for the per-album-copy
-  layout. Each ref's `variants` is populated with the produced paths.
+- Process stage iterates `(album, &album.images[i], album.resolved_config)`
+  tuples, resolving each image's `canonical_id` into
+  `manifest.canonical_images` for shared content lookup. It computes
+  the params hash from the album's resolved config and consults the
+  cache; cache hits skip re-encoding, misses encode once and insert.
+  **One encode per unique `(content_hash, params_hash)` across the
+  whole site** — two albums with the same config on a shared image =
+  one encode; two albums with different configs = two encodes. This
+  is already the cache's existing contract (`cache.rs:137`).
+- Output path construction still walks `album.images` for the
+  per-album-copy layout. Each album image's produced variant paths
+  get attached to the ref (new `variants` field added in this phase).
 - Cache unchanged (already content-addressed + params-aware).
-- Tests: reuse fixture + add (a) same bytes, same config, two albums →
-  one encode, two output copies; (b) same bytes, different
+- Tests: reuse fixture + add (a) same bytes, same config, two albums
+  → one encode, two output copies; (b) same bytes, different
   `[thumbnails].aspect_ratio` per album → two encodes, correct
   per-album outputs.
 - Estimated: ~300-500 LOC.
 
-### Phase 3 — Migrate generate to the new shape
+### Phase 3 — Migrate generate to read canonical + refs
 
-- Generate walks `album.images` (now `Vec<ImageRef>`), resolves
-  titles/descriptions per-ref → per-image fallback.
-- Full-index page iterates `manifest.images` directly — natural dedup.
-- Templates and URL construction: no URL changes (already ordinal-
-  based per album).
+- Generate walks `album.images` as today, but for each image resolves
+  title and description with precedence: ref-level (filename title,
+  sidecar description) → canonical-level (IPTC, once populated on
+  `CanonicalImage`) → none.
+- Full-index page iterates `manifest.canonical_images` directly and
+  renders one entry per unique content — natural dedup — linking into
+  every album that references it. Existing template keeps working;
+  the iteration source changes.
+- URL construction: no changes (URLs are already ordinal-based per
+  album).
 - Tests: existing renderer tests should mostly pass with minor
-  updates; add a two-album-same-image test that confirms one entry in
-  `/all-photos/`.
+  updates; add a two-album-same-image test that confirms one entry
+  in `/all-photos/`.
 - Estimated: ~400-700 LOC.
 
-### Phase 4 — Drop the old nested shape + bump schema_version
+### Phase 4 — Promote canonical_images to authoritative + schema_version bump
 
-- Remove `Album.images: Vec<Image>` field.
-- Add `schema_version: 2` to the manifest root.
+- Move IPTC title/description, raw dimensions, and any other
+  content-derived metadata onto `CanonicalImage` (populated by process
+  when it first decodes the image).
+- Simplify `Image` to the per-album reference shape: filename title,
+  sidecar description, position, variants, `canonical_id`. This is
+  the point at which we can rename `Image` → `ImageRef` and
+  `CanonicalImage` → `Image` if we want the final naming; or keep
+  the current names for stability.
+- Bump the manifest's `schema_version` to `2`. Coordinate the bump
+  with `arthur-debert/simple-gal-action` per §5.1.
 - Update every remaining test that hand-constructs manifests.
 - CHANGELOG + README updates.
 - Estimated: ~200-400 LOC, mostly test migration.

--- a/docs/dev/data-model-refactor.md
+++ b/docs/dev/data-model-refactor.md
@@ -1,0 +1,333 @@
+# Data Model Refactor — Images as First-Class Entities
+
+> **Status:** design / pre-implementation. This refactor precedes the
+> auto-reindex simplification (which is largely subsumed by it). Open
+> questions are called out inline.
+
+## 1. Motivation (validated against code)
+
+Today the manifest is a strict tree: `Manifest { albums: Vec<Album> }`,
+`Album { images: Vec<Image> }`. Two byte-identical images at two different
+paths become two separate `Image` records — they share one cache entry
+(content-addressed at `cache.rs:137`) but have duplicated metadata and
+output bookkeeping.
+
+Concrete consequences that surfaced during the analysis:
+
+- **Ordering is entangled with filename identity.** The `NNN-` prefix is
+  both an ordering hint and a bit of output-filename identity — renaming
+  a file re-sorts the album AND rewrites every AVIF output filename for
+  that image. The auto-reindex feature exists to paper over this
+  entanglement.
+- **Reusing an image across albums requires duplicating the file.** The
+  cache dedupes the encode (work savings), but the manifest still models
+  two `Image` records with independent sidecars, URLs, and positions.
+- **"All Photos" has no dedup.** A flat iterator over
+  `for album in manifest.albums; for image in album.images` would list a
+  shared image twice.
+- **Sidecar-per-path is a feature, not a bug.** The current metadata
+  precedence is sidecar `.txt` > IPTC caption for description; IPTC >
+  filename for title (`metadata.rs:29-35`). That means per-album caption
+  overrides already work if the user puts different `.txt` next to each
+  copy. Preserve this.
+
+## 2. Target model
+
+Proposed top-level shape (names indicative):
+
+```rust
+struct Manifest {
+    config: SiteConfig,
+    images: Vec<Image>,          // first-class, keyed by ImageId
+    albums: Vec<Album>,
+    pages: Vec<Page>,             // unchanged
+    nav: Vec<NavItem>,            // unchanged
+}
+
+/// Stable identity for an image across the whole site.
+struct ImageId(String);           // SHA-256 of the source file bytes
+
+struct Image {
+    id: ImageId,
+    /// A "canonical" path used for IO (first occurrence wins).
+    source_path: PathBuf,
+    /// Raw pixel dimensions — content-derived, config-independent.
+    width: u32,
+    height: u32,
+    /// IPTC-derived metadata resolved once per unique content.
+    iptc_title: Option<String>,
+    iptc_description: Option<String>,
+    /// All source filesystem paths where this content appears.
+    /// Lets us clean up stale output across renames.
+    aliases: Vec<PathBuf>,
+}
+
+struct Album {
+    slug: String,
+    title: String,
+    description: Option<String>,
+    /// Image refs in album-specific order. Position is implicit (index).
+    images: Vec<ImageRef>,
+}
+
+struct ImageRef {
+    image_id: ImageId,
+    /// Per-album filename-derived title (e.g. "Dawn" from `001-Dawn.jpg`).
+    /// Only filename title — IPTC lives on the Image.
+    filename_title: Option<String>,
+    /// Per-album sidecar-derived description. Sidecar stays path-local.
+    sidecar_description: Option<String>,
+    /// Processed output variants for this ref, under this album's
+    /// resolved config. A shared image in two albums with different
+    /// `[images]` / `[thumbnails]` config has two different variant
+    /// lists here — the cache (keyed by `content_hash + params_hash`)
+    /// transparently deduplicates only when the params also match.
+    variants: Vec<ProcessedVariant>,
+}
+```
+
+**Important:** only content-derived fields live on `Image`. Anything that
+depends on album config (responsive sizes, thumbnail aspect ratio,
+quality, sharpening) lives under `ImageRef.variants` because config
+cascades per-album — the same source image in Album A (sizes=[800, 1400])
+and Album B (sizes=[400, 800]) produces two different sets of outputs.
+The cache's existing `(content_hash, params_hash)` key still deduplicates
+encode work only when the config actually matches.
+
+Resolution rules (per-album, at render time):
+
+- Title = `ref.filename_title` → `image.iptc_title` → fallback.
+- Description = `ref.sidecar_description` → `image.iptc_description` →
+  none.
+
+The same `Image` in two albums sees two different `ImageRef`s, so
+different `filename_title` / `sidecar_description` naturally flow
+through. Single encode, single cache entry, dedup'd "All Photos."
+
+## 3. Open design questions
+
+### 3.1 Image identity: bytes only, or bytes + IPTC?
+
+- **(a) Bytes only** (proposed): `ImageId = SHA-256(file_bytes)`. Any
+  IPTC edit yields a new `ImageId` because the bytes change. Matches
+  what the cache already does.
+- **(b) Pixel bytes only:** decode → re-hash raw RGBA. Stable across
+  IPTC edits but requires decoding every candidate, even cache hits —
+  and costs a re-hash on every scan.
+
+**Recommendation: (a).** The user's "new caption shouldn't invalidate
+the images" goal is served better by moving caption off the Image
+entirely (onto the `ImageRef` as `sidecar_description`). Bytes-only
+identity keeps scan fast.
+
+### 3.2 AVIF output filenames — per-album copies or shared pool?
+
+A single content-hashed source now backs multiple albums' HTML pages.
+Two ways:
+
+- **(a) Per-album copy** (proposed): album output dirs each get their
+  own `{source_stem}-{size}.avif`. The cache deduplicates the encode
+  work; the output dir gets copies (cheap, already implemented at
+  `process.rs:591-621`). No URL/path change. Deployment-compatible.
+- **(b) Shared pool:** one `pool/{id_prefix}-{size}.avif` referenced
+  from every album page. Cheaper disk in `dist/`, but every deployed
+  site's HTML references change → full cache-bust for users.
+
+**Recommendation: (a).** Disk in `dist/` is cheap; user trust in stable
+URLs is expensive.
+
+### 3.3 Sidecar resolution — per-ref (today) or per-image?
+
+Today sidecars are read per-path during scan, so placing a different
+`.txt` next to each copy gives you different descriptions. The new
+model puts that on `ImageRef.sidecar_description`, preserving the same
+behavior. No change needed. Keep it per-ref.
+
+### 3.4 How does a user express "use this image in another album"?
+
+Filesystem-is-source-of-truth is a core premise, so the answer has to
+live on disk, not in a database. Options:
+
+- **(a) Symlinks:** `content/other-album/07-sunset.jpg ->
+  ../first-album/05-sunset.jpg`. Zero schema change. Scan already
+  follows the path; content hash dedups automatically.
+- **(b) Hard duplicates:** user just copies the file. Works today via
+  the cache. No new mechanism needed — the refactor only dedups the
+  manifest-level bookkeeping.
+- **(c) A reference file:** `other-album/07-sunset.jpg.ref` pointing
+  at a canonical path. Adds a new on-disk convention.
+
+**Recommendation:** (b) is already how things work and needs zero UX
+change. (a) is a natural extension users can choose themselves. Don't
+add (c) unless a real use-case demands it.
+
+### 3.5 JSON manifest schema — bump version, or maintain dual shape?
+
+Tooling that reads `manifest.json` today expects the nested shape.
+
+- **(a) Hard break with a version bump:** new `schema_version: 2` at
+  root; consumers have to adapt. Simplest code.
+- **(b) Dual-serialize for one release:** emit both shapes during a
+  deprecation window.
+
+**Recommendation: (a).** The generator, process stage, and generate
+stage are the only in-repo consumers, and we update them in lockstep.
+External tooling is not known to exist for this project. Cleaner to
+cut once.
+
+## 4. Phased implementation plan
+
+Each phase is its own PR, each lands with a green suite, each is
+reviewable standalone. Targets `main`.
+
+### Phase 1 — Introduce the types, scan produces both shapes
+
+- Add `ImageId`, flat `Manifest.images: Vec<Image>`, `ImageRef`
+  alongside the existing `Album.images: Vec<Image>`.
+- Scan populates both: nested vec (old) AND flat vec + refs (new).
+- No consumer changes yet. All existing tests still pass.
+- Unit tests: scan produces consistent views between the two shapes;
+  byte-identical images in two albums collapse to one `Image` in the
+  flat vec, two `ImageRef` in the albums.
+- Estimated: ~400-600 LOC, 2-3 days.
+
+### Phase 2 — Migrate process to the new shape
+
+- Process stage iterates `(ImageRef, album.resolved_config)` tuples.
+  For each ref it computes the params hash from the album's resolved
+  config and consults the cache; cache hits skip re-encoding, misses
+  encode once and insert. **One encode per unique
+  `(content_hash, params_hash)` across the whole site** — two albums
+  with the same config on a shared image = one encode; two albums
+  with different configs = two encodes. This is already the cache's
+  existing contract (`cache.rs:137`).
+- Output path construction walks refs per album for the per-album-copy
+  layout. Each ref's `variants` is populated with the produced paths.
+- Cache unchanged (already content-addressed + params-aware).
+- Tests: reuse fixture + add (a) same bytes, same config, two albums →
+  one encode, two output copies; (b) same bytes, different
+  `[thumbnails].aspect_ratio` per album → two encodes, correct
+  per-album outputs.
+- Estimated: ~300-500 LOC.
+
+### Phase 3 — Migrate generate to the new shape
+
+- Generate walks `album.images` (now `Vec<ImageRef>`), resolves
+  titles/descriptions per-ref → per-image fallback.
+- Full-index page iterates `manifest.images` directly — natural dedup.
+- Templates and URL construction: no URL changes (already ordinal-
+  based per album).
+- Tests: existing renderer tests should mostly pass with minor
+  updates; add a two-album-same-image test that confirms one entry in
+  `/all-photos/`.
+- Estimated: ~400-700 LOC.
+
+### Phase 4 — Drop the old nested shape + bump schema_version
+
+- Remove `Album.images: Vec<Image>` field.
+- Add `schema_version: 2` to the manifest root.
+- Update every remaining test that hand-constructs manifests.
+- CHANGELOG + README updates.
+- Estimated: ~200-400 LOC, mostly test migration.
+
+### Phase 5 — Auto-reindex simplification (optional, post-refactor)
+
+Once the refactor lands, the auto-reindex feature collapses:
+
+- AVIF filename is already `{source_stem}-{size}.avif`, and source
+  filenames' `NNN-` prefixes no longer affect ordering (order is
+  `Vec<ImageRef>` position). So renaming source files has no build-
+  output effect; it's purely cosmetic.
+- `[auto_indexing].auto` config mode enum collapses to a single
+  boolean (or goes away). Keep the `reindex` CLI command as a source
+  tidying tool.
+- Estimated: ~100-200 LOC, mostly deletion.
+
+## 5. Migration & backward compatibility
+
+- **Content directory:** no changes required. Users' filesystems are
+  already valid input.
+- **Deployed `dist/`:** URL paths unchanged (slug-based). AVIF output
+  filenames unchanged (per-album copies). No cache-bust.
+- **JSON manifest consumers:** hard break at Phase 4. See §5.1.
+- **Cache on disk:** unchanged. Content hash + params hash is still
+  the key.
+
+### 5.1 GitHub Action coordination
+
+The official `arthur-debert/simple-gal-action` is a known external
+consumer (it installs the binary and runs `build`). Before shipping
+Phase 4:
+
+1. **Audit** the action's source for any manifest.json parsing. If it
+   only invokes the CLI and ships `dist/`, no change is required and
+   this whole concern evaporates.
+2. **If it does parse the manifest**, open a tracking issue on
+   `arthur-debert/simple-gal-action` describing the schema shape
+   change and linking this doc.
+3. **Release the action as a new major version** after Phase 4 lands.
+   GitHub Actions don't auto-update across majors (users pin
+   `@v1` or `@v2`), so a major bump gives existing users a stable
+   floor on the old simple-gal/schema version while opting in to the
+   new shape by bumping their workflow ref.
+4. **Document the version compat** in both repos' READMEs:
+   `simple-gal-action@v1` → `simple-gal` up to the last pre-refactor
+   release; `simple-gal-action@v2` → `simple-gal` from v0.20.0+.
+
+## 6. Interaction with auto-reindex
+
+Auto-reindex as it ships in v0.19.0 is essentially a workaround for
+the current model. After this refactor:
+
+- The reindex CLI command stays useful as a source-tidying utility
+  (nice `ls` / git diff). Output build is unaffected.
+- `[auto_indexing].auto = "export_only"` becomes tautological — output
+  is already normalized by virtue of ordinal-based naming. The enum
+  can collapse or be dropped.
+- The in-place rename of `source_only` is a purely optional
+  convenience; no behavior hangs on it.
+
+**Implication:** don't ship the auto-reindex simplification before the
+refactor. The code that would normalize AVIF filenames is exactly the
+code that gets rewritten in Phase 2.
+
+## 7. Risks
+
+1. **Sidecar-per-path behavior must be preserved.** Regression here
+   silently reverts user-visible captions. Covered by tests, but worth
+   flagging in every phase PR.
+2. **Phase 1 doubles the manifest size briefly** (both shapes
+   co-exist). Minor memory/serialization cost during the transition.
+3. **Generate stage tests are fixture-heavy.** Phase 3 has the largest
+   test-migration blast radius. Plan for it.
+4. **Scan determinism.** When two albums reference the same image,
+   which one becomes the `Image.source_path`? Rule: first-by-
+   directory-scan-order. Test it explicitly.
+
+## 8. Rough effort
+
+- 5 PRs (phases), each independently reviewable + green CI.
+- ~2-3 weeks of focused work with dense test coverage.
+- Minor version bump (v0.20.0) when Phase 4 lands (schema_version
+  bump is user-visible).
+
+## 9. Decision log
+
+All six design questions approved:
+
+- [x] Image identity = **bytes only** (§3.1).
+- [x] AVIF filenames = **per-album copies** (§3.2).
+- [x] Sidecars stay **per-ref** (§3.3).
+- [x] Cross-album reuse = **user duplicates or symlinks, no new
+      convention** (§3.4).
+- [x] Manifest schema = **hard break + version bump** (§3.5), with
+      `simple-gal-action` coordination per §5.1.
+- [x] Auto-reindex simplification **deferred** to Phase 5 (§6).
+
+Additional decision:
+- [x] Processed variants live on `ImageRef`, not `Image`, because
+      config cascades per-album and the same source can have different
+      responsive sizes / thumbnail ratios / quality in different
+      albums (§2).
+
+Phase 1 can start.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -223,10 +223,25 @@ fn build_content_index(entries: &HashMap<String, CacheEntry>) -> HashMap<String,
 }
 
 /// SHA-256 hash of a file's contents, returned as a hex string.
+///
+/// Streams the file through the hasher via a buffered reader so large
+/// images don't force the whole byte range into memory. Matters for the
+/// scan stage (which hashes every image to build the canonical index)
+/// and for the cache's lookup path (one hash per candidate file).
 pub fn hash_file(path: &Path) -> io::Result<String> {
-    let bytes = std::fs::read(path)?;
-    let digest = Sha256::digest(&bytes);
-    Ok(format!("{:x}", digest))
+    use std::io::Read;
+    let file = std::fs::File::open(path)?;
+    let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 16 * 1024];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// SHA-256 hash of encoding parameters for a responsive variant.

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -58,7 +58,7 @@ use crate::metadata;
 use crate::naming::parse_entry_name;
 use crate::types::{NavItem, Page};
 use confique::Layer;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -88,6 +88,44 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub config: SiteConfig,
+    /// First-class image entities keyed by content hash. Every [`Image`]
+    /// below carries a `canonical_id` pointing into this list, and two
+    /// byte-identical images at different paths collapse to one entry
+    /// here with both paths captured in [`CanonicalImage::aliases`].
+    ///
+    /// This is the flat view introduced by Phase 1 of the data-model
+    /// refactor (see `docs/dev/data-model-refactor.md`). It runs
+    /// alongside the nested `Album.images: Vec<Image>` shape during the
+    /// transition; later phases migrate consumers onto the flat view
+    /// and drop the nested one.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub canonical_images: Vec<CanonicalImage>,
+}
+
+/// Stable, content-addressed identity for an image.
+///
+/// The inner string is the hex-encoded SHA-256 of the source file
+/// bytes — matches the format used by [`crate::cache::hash_file`] so
+/// the cache and the manifest can share lookups.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ImageId(pub String);
+
+/// First-class image entity: one record per unique source content.
+///
+/// Fields here are strictly content-derived (identity + filesystem
+/// paths where the bytes appear). Album-specific data — caption
+/// overrides, sort position, per-album processed variants — lives on
+/// the per-album [`Image`] struct, which cascaded config determines.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalImage {
+    pub id: ImageId,
+    /// Canonical path used for IO (first occurrence in scan order).
+    pub source_path: String,
+    /// Every other source filesystem path where this content appears.
+    /// Empty when the image is only referenced from one location.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
 }
 
 /// Album with its images and resolved configuration.
@@ -129,6 +167,12 @@ pub struct Image {
     /// Image description from sidecar `.txt` file (e.g., `001-photo.txt` for `001-photo.jpg`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Pointer into [`Manifest::canonical_images`] — shared across every
+    /// album that references the same byte-identical source. Populated
+    /// by the dedup pass at the end of [`scan`]; absent only on manifests
+    /// produced before Phase 1 of the data-model refactor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_id: Option<ImageId>,
 }
 
 pub fn scan(root: &Path) -> Result<Manifest, ScanError> {
@@ -163,13 +207,71 @@ pub fn scan(root: &Path) -> Result<Manifest, ScanError> {
     // Root-level resolved config for CSS generation
     let config = root_config;
 
+    // Build the flat canonical view: hash each image's bytes, dedupe by
+    // content hash, stamp every `Image.canonical_id` with a pointer into
+    // the new `canonical_images` list. See `docs/dev/data-model-refactor.md`
+    // for the rationale. This runs after all albums have been collected so
+    // one pass covers the whole site.
+    let canonical_images = build_canonical_index(root, &mut albums)?;
+
     Ok(Manifest {
         navigation: nav_items,
         albums,
         pages,
         description,
         config,
+        canonical_images,
     })
+}
+
+/// Hash every image across every album and build the flat canonical
+/// index. Mutates `albums` to stamp each [`Image`] with its
+/// [`ImageId`]. See [`Manifest::canonical_images`] for the larger
+/// picture.
+fn build_canonical_index(
+    root: &Path,
+    albums: &mut [Album],
+) -> Result<Vec<CanonicalImage>, ScanError> {
+    use std::collections::HashMap;
+
+    let mut canonical: Vec<CanonicalImage> = Vec::new();
+    // Maps `ImageId` → index into `canonical` so we can push aliases
+    // cheaply without re-scanning the vector.
+    let mut by_id: HashMap<ImageId, usize> = HashMap::new();
+
+    for album in albums.iter_mut() {
+        for image in album.images.iter_mut() {
+            // `Image.source_path` is always stored relative to `root`
+            // (see `scan_directory`), so prepend `root` for the read.
+            let abs_path = root.join(&image.source_path);
+            let hex = crate::cache::hash_file(&abs_path)?;
+            let id = ImageId(hex);
+
+            match by_id.get(&id) {
+                Some(&idx) => {
+                    // Already seen these bytes — record this path as an
+                    // alias unless it matches the canonical one (which
+                    // it won't, since we only recurse into this branch
+                    // on duplicate hashes from distinct scan entries).
+                    if canonical[idx].source_path != image.source_path {
+                        canonical[idx].aliases.push(image.source_path.clone());
+                    }
+                }
+                None => {
+                    let idx = canonical.len();
+                    canonical.push(CanonicalImage {
+                        id: id.clone(),
+                        source_path: image.source_path.clone(),
+                        aliases: Vec::new(),
+                    });
+                    by_id.insert(id.clone(), idx);
+                }
+            }
+            image.canonical_id = Some(id);
+        }
+    }
+
+    Ok(canonical)
 }
 
 /// Convert a relative path to a slug path by stripping number prefixes from each component.
@@ -578,6 +680,9 @@ fn build_album(
                 slug,
                 title,
                 description,
+                // Populated in `build_canonical_index` after scan collects
+                // every image across every album.
+                canonical_id: None,
             }
         })
         .collect();
@@ -1651,5 +1756,169 @@ mod tests {
         let manifest = scan(tmp.path()).unwrap();
         // No thumb, no image #1 → falls back to first by sort order (005)
         assert!(manifest.albums[0].preview_image.contains("005-first"));
+    }
+
+    // =========================================================================
+    // Phase 1 of the data-model refactor: canonical_images flat view.
+    // See docs/dev/data-model-refactor.md.
+    //
+    // These tests build their own byte-distinct TempDir instead of using the
+    // shared `fixtures/content/` — the fixture JPEGs are placeholder bytes
+    // that all hash to the same value, which hides the dedup semantics
+    // we're trying to exercise.
+    // =========================================================================
+
+    /// Build a minimal site with two albums whose images have exact
+    /// byte contents we dictate. `layout` is `[(album_dir, image_name,
+    /// bytes), ...]`. Scan doesn't decode; it only hashes, so synthetic
+    /// bytes are fine for exercising canonical-ID logic.
+    fn setup_synthetic(layout: &[(&str, &str, &[u8])]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        for (album, name, bytes) in layout {
+            let album_dir = tmp.path().join(album);
+            fs::create_dir_all(&album_dir).unwrap();
+            fs::write(album_dir.join(name), bytes).unwrap();
+        }
+        tmp
+    }
+
+    fn find_ref_by_path<'a>(m: &'a Manifest, suffix: &str) -> &'a Image {
+        m.albums
+            .iter()
+            .flat_map(|a| &a.images)
+            .find(|i| i.source_path.ends_with(suffix))
+            .unwrap_or_else(|| panic!("no image ref ending in {suffix}"))
+    }
+
+    #[test]
+    fn canonical_images_populated_for_every_image_ref() {
+        let tmp = setup_synthetic(&[
+            ("010-Alpha", "001-a.jpg", b"bytes-alpha"),
+            ("010-Alpha", "002-b.jpg", b"bytes-beta"),
+            ("020-Beta", "001-c.jpg", b"bytes-gamma"),
+        ]);
+        let manifest = scan(tmp.path()).unwrap();
+        for album in &manifest.albums {
+            for image in &album.images {
+                let id = image
+                    .canonical_id
+                    .as_ref()
+                    .expect("scan must stamp canonical_id on every image");
+                assert!(
+                    manifest.canonical_images.iter().any(|c| &c.id == id),
+                    "image {:?} points at unknown canonical id {:?}",
+                    image.source_path,
+                    id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn canonical_images_deduplicates_identical_bytes_in_two_albums() {
+        // Same bytes in two albums → one canonical entry, both paths
+        // captured (one as source_path, the other as alias).
+        let shared = b"shared-bytes".as_slice();
+        let tmp = setup_synthetic(&[
+            ("010-Alpha", "001-a.jpg", shared),
+            ("020-Beta", "001-copy.jpg", shared),
+        ]);
+        let manifest = scan(tmp.path()).unwrap();
+
+        let a_id = find_ref_by_path(&manifest, "010-Alpha/001-a.jpg")
+            .canonical_id
+            .clone()
+            .unwrap();
+        let b_id = find_ref_by_path(&manifest, "020-Beta/001-copy.jpg")
+            .canonical_id
+            .clone()
+            .unwrap();
+        assert_eq!(a_id, b_id, "byte-identical copies share an ImageId");
+
+        let canonical = manifest
+            .canonical_images
+            .iter()
+            .find(|c| c.id == a_id)
+            .unwrap();
+        let mut all_paths: Vec<&str> = std::iter::once(canonical.source_path.as_str())
+            .chain(canonical.aliases.iter().map(|s| s.as_str()))
+            .collect();
+        all_paths.sort();
+        assert_eq!(
+            all_paths,
+            vec!["010-Alpha/001-a.jpg", "020-Beta/001-copy.jpg"]
+        );
+        assert_eq!(
+            manifest.canonical_images.len(),
+            1,
+            "two refs but one unique content hash"
+        );
+    }
+
+    #[test]
+    fn canonical_count_matches_unique_content() {
+        // 4 refs, 3 distinct byte strings → 3 canonical entries.
+        let tmp = setup_synthetic(&[
+            ("010-Alpha", "001-a.jpg", b"content-1"),
+            ("010-Alpha", "002-b.jpg", b"content-2"),
+            ("020-Beta", "001-c.jpg", b"content-3"),
+            ("020-Beta", "002-d.jpg", b"content-1"), // duplicate of 1-a
+        ]);
+        let manifest = scan(tmp.path()).unwrap();
+        let total_refs: usize = manifest.albums.iter().map(|a| a.images.len()).sum();
+        assert_eq!(total_refs, 4);
+        assert_eq!(manifest.canonical_images.len(), 3);
+    }
+
+    #[test]
+    fn canonical_entry_source_path_is_first_scan_occurrence() {
+        // Albums are scanned in sort order (lexicographic by path),
+        // so 010-Alpha's copy wins canonical; 020-Beta's becomes the alias.
+        let shared = b"shared".as_slice();
+        let tmp = setup_synthetic(&[
+            ("010-Alpha", "001-a.jpg", shared),
+            ("020-Beta", "001-copy.jpg", shared),
+        ]);
+        let manifest = scan(tmp.path()).unwrap();
+        let id = find_ref_by_path(&manifest, "010-Alpha/001-a.jpg")
+            .canonical_id
+            .clone()
+            .unwrap();
+        let canonical = manifest
+            .canonical_images
+            .iter()
+            .find(|c| c.id == id)
+            .unwrap();
+        assert_eq!(canonical.source_path, "010-Alpha/001-a.jpg");
+        assert_eq!(canonical.aliases, vec!["020-Beta/001-copy.jpg".to_string()]);
+    }
+
+    #[test]
+    fn byte_different_images_get_separate_canonical_ids() {
+        // Even with identical filenames, different bytes hash differently.
+        let tmp = setup_synthetic(&[
+            ("010-Alpha", "001-cover.jpg", b"alpha-cover"),
+            ("020-Beta", "001-cover.jpg", b"beta-cover"),
+        ]);
+        let manifest = scan(tmp.path()).unwrap();
+        let a = find_ref_by_path(&manifest, "010-Alpha/001-cover.jpg")
+            .canonical_id
+            .clone()
+            .unwrap();
+        let b = find_ref_by_path(&manifest, "020-Beta/001-cover.jpg")
+            .canonical_id
+            .clone()
+            .unwrap();
+        assert_ne!(a, b);
+        assert_eq!(manifest.canonical_images.len(), 2);
+    }
+
+    #[test]
+    fn canonical_entry_without_duplicates_has_empty_aliases() {
+        // A content hash seen exactly once → aliases vec empty.
+        let tmp = setup_synthetic(&[("010-Alpha", "001-only.jpg", b"unique")]);
+        let manifest = scan(tmp.path()).unwrap();
+        assert_eq!(manifest.canonical_images.len(), 1);
+        assert!(manifest.canonical_images[0].aliases.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the data-model refactor planned in `docs/dev/data-model-refactor.md`. This PR introduces the new image-as-first-class shape **alongside** the existing nested `Album.images: Vec<Image>` — no consumer behavior changes yet. Process and generate still walk the old shape and ignore the new fields. Later phases migrate them one by one.

## What lands

- `ImageId(String)` — content-addressed identity (hex SHA-256).
- `CanonicalImage { id, source_path, aliases }` — one record per unique byte content in the site.
- `Manifest.canonical_images: Vec<CanonicalImage>` — the flat view.
- `Image.canonical_id: Option<ImageId>` — per-album refs point at their canonical entry. Optional so manifests written before this change still deserialize.
- `build_canonical_index` — post-scan pass that hashes every image (reusing `cache::hash_file` so manifest and cache share the same digest format), dedupes by ImageId, and stamps every ref.
- `docs/dev/data-model-refactor.md` — the full plan (5 phases, ~2-3 weeks of work, minor-version bump target when Phase 4 lands).

## Safety guarantees (covered by tests)

- Byte-identical images in two albums collapse to **one** canonical entry with both paths captured (first scan occurrence wins `source_path`; others land in `aliases`).
- Byte-different images with the same filename get **separate** canonical IDs — no false dedup.
- `aliases` is empty when an image appears exactly once.
- Every per-album `Image.canonical_id` points at a real entry in `canonical_images`.

## Tests

6 new tests in `scan::tests` (`canonical_images_populated_for_every_image_ref`, `canonical_images_deduplicates_identical_bytes_in_two_albums`, `canonical_count_matches_unique_content`, `canonical_entry_source_path_is_first_scan_occurrence`, `byte_different_images_get_separate_canonical_ids`, `canonical_entry_without_duplicates_has_empty_aliases`).

They use a synthetic `TempDir` helper (`setup_synthetic`) with byte-distinct content rather than the shared `fixtures/content/` — the fixture JPEGs are placeholder bytes that all hash to the same value, which would hide the dedup semantics we're exercising. Flagged in a test-module comment.

Full suite: 468 lib tests (up from 462), all 8 integration suites unchanged, green.

## Deferred to later phases

- Phase 2: migrate process stage to iterate `(ImageRef, album_config)` tuples, encoding once per `(content, params)` pair.
- Phase 3: migrate generate stage to read from refs + canonical, with natural dedup on the All Photos page.
- Phase 4: drop `Album.images: Vec<Image>`, bump `schema_version`. Coordinate with `simple-gal-action` (see §5.1 of the plan).
- Phase 5 (optional): collapse `[auto_indexing].auto` now that ordering is fully decoupled from filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)