### PR TITLE
ci: add github policy files and copilot review workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arthur-debert

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Copilot Instructions
+
+This is a Rust project (CLI, library crate, or workspace).
+
+## Before suggesting a fix
+
+- Run the project's checks: `scripts/check` if it exists (umbrella for fmt +
+  clippy + tests), otherwise `cargo fmt --check && cargo clippy -- -D warnings
+  && cargo test`. CI runs the same; suggestions that don't pass won't merge.
+- Never propose changes that leave tests failing.
+- Update the changelog's `Unreleased` section for user-visible changes
+  (`CHANGELOG_UNRELEASED.md` if the project has one, otherwise the
+  `## [Unreleased]` section of `CHANGELOG.md`).
+
+## Style and scope
+
+- Keep changes minimal. Don't add features, refactor, or introduce abstractions
+  beyond what the task requires.
+- No backwards-compatibility hacks: no `// removed` comments, no renaming unused
+  vars to `_var`, no shim modules. If something is unused, delete it.
+- No fallbacks, defaults, or feature flags unless the PR explicitly asks for them.
+- Default to no comments. Well-named identifiers carry the *what*. Reserve
+  comments for non-obvious *why* (hidden constraint, workaround, surprising
+  invariant).
+- Trust internal code and framework guarantees. Only validate at system
+  boundaries (user input, external commands, filesystem entry).
+
+## What will get pushed back on
+
+- Suggestions that ignore content under `docs/`.
+- Style nits in code that already follows the project's style.
+- Defensive error handling for invariants the type system already enforces.
+- Comments that restate what the code does.
+- Pinning org-internal reusable workflows (e.g. `arthur-debert/dagentic`) to
+  SHA — the reusable pattern is "fix once, propagate", and same-owner
+  supply-chain risk is negligible.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,10 +4,11 @@ This is a Rust project (CLI, library crate, or workspace).
 
 ## Before suggesting a fix
 
-- Run the project's umbrella check script if one exists (commonly
-  `scripts/check` or `scripts/pre-commit` — `ls scripts/` to see which);
-  otherwise `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
-  CI runs the same; suggestions that don't pass won't merge.
+- Run the project's umbrella check script if one exists (in `scripts/`,
+  commonly named `check`, `pre-commit`, `ci.sh`, or `rust-pre-commit` — run
+  `ls scripts/` to see which); otherwise `cargo fmt --check && cargo clippy
+  -- -D warnings && cargo test`. CI runs the same; suggestions that don't
+  pass won't merge.
 - Never propose changes that leave tests failing.
 - Update the changelog's `Unreleased` section for user-visible changes
   (`CHANGELOG_UNRELEASED.md` if the project has one, otherwise the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,9 +4,10 @@ This is a Rust project (CLI, library crate, or workspace).
 
 ## Before suggesting a fix
 
-- Run the project's checks: `scripts/check` if it exists (umbrella for fmt +
-  clippy + tests), otherwise `cargo fmt --check && cargo clippy -- -D warnings
-  && cargo test`. CI runs the same; suggestions that don't pass won't merge.
+- Run the project's umbrella check script if one exists (commonly
+  `scripts/check` or `scripts/pre-commit` — `ls scripts/` to see which);
+  otherwise `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
+  CI runs the same; suggestions that don't pass won't merge.
 - Never propose changes that leave tests failing.
 - Update the changelog's `Unreleased` section for user-visible changes
   (`CHANGELOG_UNRELEASED.md` if the project has one, otherwise the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Checklist
+
+- [ ] Changelog `Unreleased` section updated (or chore/docs-only)
+- [ ] `scripts/check` passes locally (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`)
+- [ ] Tests added or updated for behavior changes
+
+## Notes for reviewers
+
+<!-- Optional: context to help triage Copilot's review faster. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] Changelog `Unreleased` section updated (or chore/docs-only)
-- [ ] `scripts/check` or `scripts/pre-commit` passes locally (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`)
+- [ ] Project umbrella check passes locally — `scripts/check`, `scripts/pre-commit`, `scripts/ci.sh`, or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
 - [ ] Tests added or updated for behavior changes
 
 ## Notes for reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] Changelog `Unreleased` section updated (or chore/docs-only)
-- [ ] `scripts/check` passes locally (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`)
+- [ ] `scripts/check` or `scripts/pre-commit` passes locally (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`)
 - [ ] Tests added or updated for behavior changes
 
 ## Notes for reviewers

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,15 @@
+name: Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Canonical .github/ policy files synced from `~/h/dotfiles/gh/templates/rust`. Same shape as `arthur-debert/dodot#74` and `arthur-debert/padz#113`.

- CODEOWNERS, dependabot, PR template, copilot-instructions
- workflows/copilot-review.yml — auto-request Copilot on each PR via the reusable workflow in `arthur-debert/dagentic`

Companion to the new `main-branch-protection` ruleset (PR required, `lint` + `test` must pass, 0 approvals required).

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI tooling, no behavior change)
- [x] `scripts/check` passes locally (no code changes)
- [x] Tests added or updated for behavior changes (N/A — config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)