### PR TITLE
chore(docs): migrate docs.yml to canonical mdbook.yml@v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,8 @@
+# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v1.
+# Book lives under `docs/` (so `book-dir: docs`); the book.toml sets
+# `build-dir = "../target/book"`, but the canonical workflow passes
+# `--dest-dir` as an absolute path so `output-dir` is authoritative.
+
 name: Deploy Docs
 
 on:
@@ -15,38 +20,9 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install mdbook
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.44/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz \
-            | tar -xz -C "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Build book
-        run: mdbook build docs/
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: target/book
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  docs:
+    uses: arthur-debert/release/.github/workflows/mdbook.yml@v1
+    with:
+      book-dir: docs
+      output-dir: target/book


### PR DESCRIPTION
Replaces this repo's bespoke mdBook install + build + deploy with a thin caller of `arthur-debert/release/.github/workflows/mdbook.yml@v1` (introduced in arthur-debert/release#153).

Per-consumer inputs: `book-dir: docs` (book.toml lives there), `output-dir: target/book` (matches this repo's `build-dir` setting in book.toml).

Sibling PR landing simultaneously on `arthur-debert/standout`.