### PR TITLE
chore: lint cleanup for strict shell-quality gate

### DIFF
--- a/docs/dev/auto-reindex.md
+++ b/docs/dev/auto-reindex.md
@@ -57,6 +57,7 @@ Two orthogonal parameters drive the output prefix:
   independent of spacing.
 
 Examples:
+
 | spacing | padding | output                    |
 | ------- | ------- | ------------------------- |
 | 0       | 0       | `1-Foo`, `2-Bar`          |
@@ -81,10 +82,9 @@ By default the walk is **recursive**: after reindexing the children of the
 target, descend into each numbered subdirectory and reindex there too.
 `--flat` limits reindex to the target directory only.
 
-
 ## 3. CLI surface
 
-```
+```text
 simple-gal reindex [PATH] [--spacing N] [--padding P] [--flat] [--dry-run] [--yes]
 ```
 

--- a/docs/dev/data-model-refactor.md
+++ b/docs/dev/data-model-refactor.md
@@ -253,7 +253,7 @@ reviewable standalone. Targets `main`.
 - Bump the manifest's `schema_version` to `2`. Coordinate the bump
   with `arthur-debert/simple-gal-action` per §5.1.
 - Wire the nuke-on-mismatch cache-reset policy per §5.2 (clear error
-  + optional `--auto-reset-cache` flag). No in-place data migration
+  - optional `--auto-reset-cache` flag). No in-place data migration
   code.
 - Update every remaining test that hand-constructs manifests to use
   the new shape.
@@ -409,6 +409,7 @@ All six design questions approved:
 - [x] Auto-reindex simplification **deferred** to Phase 5 (§6).
 
 Additional decision:
+
 - [x] Processed variants live on `ImageRef`, not `Image`, because
       config cascades per-album and the same source can have different
       responsive sizes / thumbnail ratios / quality in different

--- a/docs/dev/data-model-refactor.md
+++ b/docs/dev/data-model-refactor.md
@@ -252,8 +252,8 @@ reviewable standalone. Targets `main`.
   the current names for stability.
 - Bump the manifest's `schema_version` to `2`. Coordinate the bump
   with `arthur-debert/simple-gal-action` per §5.1.
-- Wire the nuke-on-mismatch cache-reset policy per §5.2 (clear error
-  - optional `--auto-reset-cache` flag). No in-place data migration
+- Wire the nuke-on-mismatch cache-reset policy per §5.2 (clear error +
+  optional `--auto-reset-cache` flag). No in-place data migration
   code.
 - Update every remaining test that hand-constructs manifests to use
   the new shape.

--- a/docs/dev/photo-page-layout.md
+++ b/docs/dev/photo-page-layout.md
@@ -5,7 +5,7 @@ its layout structure, terminology, and the three rendering variants.
 
 ## Zones
 
-```
+```text
 ╔══════════════════════════════════════════════╗
 ║  Site Header                            ☰   ║  fixed top
 ╠══════════════════════════════════════════════╣
@@ -74,7 +74,7 @@ A given image has one, the other, or neither. Never both.
 
 No text metadata. Photo centered in mat, no scroll.
 
-```
+```text
 ╠══════════════════════════════════════════════╣
 ║                                              ║
 ║            ┊  top mat  ┊                     ║
@@ -98,7 +98,7 @@ No text metadata. Photo centered in mat, no scroll.
 Caption is flush below the photo, inside the mat. Photo shrinks to make room;
 mat boundary unchanged. No scroll.
 
-```
+```text
 ╠══════════════════════════════════════════════╣
 ║                                              ║
 ║            ┊  top mat  ┊                     ║
@@ -124,7 +124,7 @@ to guarantee the teaser is visible; mat dimensions unchanged. The entire
 content (matted photo + description) scrolls as a unit; Image Nav stays
 sticky at the bottom.
 
-```
+```text
 ╠══════════════════════════════════════════════╣
 ║                                              ║  ↑
 ║            ┊  top mat  ┊                     ║  │

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -24,7 +24,7 @@ cargo test --test browser_pwa -- --ignored          # Browser PWA tests (needs C
 
 `fixtures/content/` is a single dataset that covers the full feature set. Tests copy it to a temp dir via `setup_fixtures()` so they can't interfere with each other.
 
-```
+```text
 content/
 ├── config.toml                         # Root config — overrides ALL defaults
 ├── 010-Landscapes/                     # Numbered album (in nav)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD025 -- mdBook part titles use multiple top-level headings -->
 # Summary
 
 [Introduction](introduction.md)

--- a/docs/src/configuration/fonts.md
+++ b/docs/src/configuration/fonts.md
@@ -15,7 +15,7 @@ font_type = "sans"
 
 This generates a `<link>` tag pointing to:
 
-```
+```text
 https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600&display=swap
 ```
 
@@ -64,6 +64,7 @@ source = "fonts/MyFont.woff2"
 ```
 
 When `source` is set:
+
 - No Google Fonts `<link>` tag is generated.
 - A `@font-face` CSS declaration is generated inline.
 - The font file must be placed in your assets directory so it gets copied to the output.

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -56,6 +56,7 @@ quality = 90
 ```
 
 Validation rules:
+
 - `quality` must be 0--100.
 - `sizes` must contain at least one value.
 

--- a/docs/src/customization/assets.md
+++ b/docs/src/customization/assets.md
@@ -71,7 +71,7 @@ As with favicons, your files in `assets/` overwrite the defaults because assets 
 
 To use a locally hosted font instead of a Google Font:
 
-1. Place font files in `assets/fonts/`:
+- **1.** Place font files in `assets/fonts/`:
 
 ```text
 assets/
@@ -80,7 +80,7 @@ assets/
     garamond-italic.woff2
 ```
 
-1. Declare the font face in `assets/custom.css`:
+- **2.** Declare the font face in `assets/custom.css`:
 
 ```css
 @font-face {
@@ -100,7 +100,7 @@ assets/
 }
 ```
 
-1. Set the font family in `config.toml`:
+- **3.** Set the font family in `config.toml`:
 
 ```toml
 [font]

--- a/docs/src/customization/assets.md
+++ b/docs/src/customization/assets.md
@@ -6,7 +6,7 @@ The `assets/` directory holds static files -- favicons, fonts, images, and anyth
 
 Place an `assets/` directory next to your `config.toml`:
 
-```
+```text
 my-portfolio/
   config.toml
   assets/
@@ -20,7 +20,7 @@ my-portfolio/
 
 After building, these files appear at the output root:
 
-```
+```text
 dist/
   favicon.svg          # → accessible at /favicon.svg
   fonts/
@@ -73,14 +73,14 @@ To use a locally hosted font instead of a Google Font:
 
 1. Place font files in `assets/fonts/`:
 
-```
+```text
 assets/
   fonts/
     garamond.woff2
     garamond-italic.woff2
 ```
 
-2. Declare the font face in `assets/custom.css`:
+1. Declare the font face in `assets/custom.css`:
 
 ```css
 @font-face {
@@ -100,7 +100,7 @@ assets/
 }
 ```
 
-3. Set the font family in `config.toml`:
+1. Set the font family in `config.toml`:
 
 ```toml
 [font]

--- a/docs/src/customization/css-and-js.md
+++ b/docs/src/customization/css-and-js.md
@@ -105,7 +105,7 @@ Create `assets/body-end.html`:
 
 A typical setup with all three convention files:
 
-```
+```text
 my-portfolio/
   config.toml
   assets/

--- a/docs/src/deployment/github-actions.md
+++ b/docs/src/deployment/github-actions.md
@@ -81,7 +81,7 @@ To use a custom domain (e.g., `photos.example.com`):
 photos.example.com
 ```
 
-3. Configure DNS with your domain registrar -- a CNAME record pointing to `<username>.github.io`.
+1. Configure DNS with your domain registrar -- a CNAME record pointing to `<username>.github.io`.
 
 GitHub will provision an SSL certificate automatically.
 

--- a/docs/src/deployment/github-actions.md
+++ b/docs/src/deployment/github-actions.md
@@ -74,14 +74,14 @@ That is all. The workflow handles the rest.
 
 To use a custom domain (e.g., `photos.example.com`):
 
-1. In your repository settings under **Pages > Custom domain**, enter your domain.
-2. Add a `CNAME` file to the root of your content directory containing just the domain name:
+- **1.** In your repository settings under **Pages > Custom domain**, enter your domain.
+- **2.** Add a `CNAME` file to the root of your content directory containing just the domain name:
 
 ```text
 photos.example.com
 ```
 
-1. Configure DNS with your domain registrar -- a CNAME record pointing to `<username>.github.io`.
+- **3.** Configure DNS with your domain registrar -- a CNAME record pointing to `<username>.github.io`.
 
 GitHub will provision an SSL certificate automatically.
 

--- a/docs/src/pwa/installation.md
+++ b/docs/src/pwa/installation.md
@@ -31,10 +31,12 @@ The portfolio appears in the app drawer and on the home screen, and opens withou
 Desktop browsers also support PWA installation:
 
 **Chrome:**
+
 1. Visit your portfolio.
 2. Click the **install icon** in the address bar (a monitor with a down arrow), or open the three-dot menu and select **Install**.
 
 **Edge:**
+
 1. Visit your portfolio.
 2. Click the **App available** icon in the address bar, or open the three-dot menu and select **Apps > Install this site as an app**.
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -7,7 +7,7 @@ feature set with minimal data — every file is here for a reason.
 
 Used by `scan.rs` tests (copied to a temp dir via `setup_fixtures()`).
 
-```
+```text
 content/
 ├── config.toml                    # Root config — overrides ALL defaults
 ├── 010-Landscapes/                # Numbered album (in nav)


### PR DESCRIPTION
Content-only pre-cleaning ahead of release/'s strict-gate tightening (release#288). This repo's CI still runs the **relaxed** synced config (shellcheck `severity=warning`, path excludes), so proof here is **local strict lint** (`shellcheck --severity=info`, markdownlint with `MD013/MD060/line-length/table-column-style` off, MD056 kept on). No managed config or symlinks touched.

## Shell — no changes needed
All four owned shell files were already clean at `shellcheck --severity=info`:

- `bin/check-fmt`, `bin/check-lint`, `bin/release`, `app-bin/local-build-and-serve.sh` → 0 findings.

(`bin/*` symlinks into `.release/` and `bin/share/**` are out of scope.) No `live-tests/`, `scripts/`, or shell under `tests/` exists in this repo.

## Markdown — owned docs only

Finding categories fixed:

- **MD040** (bare code fence) — tagged as `text`: directory trees, ASCII layout diagrams, a CLI synopsis, and a URL block.
- **MD025** (multiple H1) — inline-disabled for `docs/src/SUMMARY.md`; mdBook part titles legitimately use multiple top-level headings.
- Mechanical `markdownlint --fix`: **MD058** (table blank lines), **MD012** (multiple blanks), **MD004** (ul `+`→`-`), **MD032** (list blank lines), **MD029** (ol renumber), **MD047** (trailing newline), **MD034** (bare URL).

## Deliberately out of scope: gallery content-data fixtures

`fixtures/content/*.md` are **gallery input** consumed by `src/scan.rs` and the integration tests — not prose docs. `050-github.md` is a deliberately URL-only external-link page; `site.md` / `description.md` are headingless captions. "Fixing" their MD041/MD034 would change demonstrated behavior, so they're left untouched (same content-class rationale as the CHANGELOG-fragment exclude). `fixtures/README.md` (a real doc) was fixed.

## Local strict-lint proof (clean)

```text
$ shellcheck --severity=info bin/check-fmt bin/check-lint bin/release app-bin/local-build-and-serve.sh
(0 findings)

$ markdownlint --config <strict> <owned docs>
(0 findings)
```

No test helpers/fixtures/bats files were changed, so the test suite was not run (nothing behavioral touched).