### PR TITLE
ci: bump release reusable workflows to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
     with:
       binary-name: simple-gal

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v1.
+# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v2.
 # Book lives under `docs/` (so `book-dir: docs`); the book.toml sets
 # `build-dir = "../target/book"`, but the canonical workflow passes
 # `--dest-dir` as an absolute path so `output-dir` is authoritative.
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mdbook.yml@v1
+    uses: arthur-debert/release/.github/workflows/mdbook.yml@v2
     with:
       book-dir: docs
       output-dir: target/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v1.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
 # Bug fixes and improvements to the release pipeline come in via a
 # bump of the @v1 floating ref, no changes here.
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
     with:
       version: ${{ inputs.version }}
       crates: simple-gal


### PR DESCRIPTION
Moves onto release/'s v2 major line (v2.0.0 = strict lint gate). Reusable workflows unchanged v1→v2; behavior-neutral. Admin-merged without the review loop per maintainer direction.