### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v3
     with:
       binary-name: simple-gal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v2.
+# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v3.
 # Book lives under `docs/` (so `book-dir: docs`); the book.toml sets
 # `build-dir = "../target/book"`, but the canonical workflow passes
 # `--dest-dir` as an absolute path so `output-dir` is authoritative.
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mdbook.yml@v2
+    uses: arthur-debert/release/.github/workflows/mdbook.yml@v3
     with:
       book-dir: docs
       output-dir: target/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
-# bump of the @v1 floating ref, no changes here.
+# bump of the @v3 floating ref, no changes here.
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v3
     with:
       version: ${{ inputs.version }}
       crates: simple-gal

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+ci: migrate release reusable-workflow callers from @v2 to @v3

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,1 +1,1 @@
-ci: migrate release reusable-workflow callers from @v2 to @v3
+- ci: migrate release reusable-workflow callers from @v2 to @v3


### PR DESCRIPTION
Bumps the arthur-debert/release reusable-workflow callers from `@v2` to `@v3` after release cut v3.0.0.

v3 is MAJOR only because release removed the deprecated singular `wasm-package` input (#634) — no consumer used it, so this is mechanical. The v2 branch is frozen at v2.21.0.

- Workflow callers bumped: `rust-cli.yml`, `rust-ci.yml`, `mdbook.yml` (uses: lines + version-mentioning comments).
- `copilot-review.yml@v1` left as-is (out of scope).
- Managed tree NOT in this PR — it arrives via the consumer's own wheel pull.

🤖 Generated with Claude Code